### PR TITLE
fix(backend): /api/v1 prefix, request logging, MigrateDSN (Issue #38)

### DIFF
--- a/backend/cmd/server/root.go
+++ b/backend/cmd/server/root.go
@@ -107,7 +107,7 @@ func runServer(cmd *cobra.Command, args []string) error {
 	log.Info().Str("host", cfg.Database.Host).Int("port", cfg.Database.Port).Msg("database connected")
 
 	// --- Migrations ---
-	if err := runMigrations(cfg.Database.DSN()); err != nil {
+	if err := runMigrations(cfg.Database.MigrateDSN()); err != nil {
 		return fmt.Errorf("running migrations: %w", err)
 	}
 	log.Info().Msg("migrations applied")

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -35,11 +35,19 @@ type DatabaseConfig struct {
 	SSLMode  string `mapstructure:"sslmode"`
 }
 
-// DSN returns the PostgreSQL connection string.
+// DSN returns the PostgreSQL connection string in key=value format (used by GORM).
 func (d DatabaseConfig) DSN() string {
 	return fmt.Sprintf(
 		"host=%s port=%d dbname=%s user=%s password=%s sslmode=%s",
 		d.Host, d.Port, d.Name, d.User, d.Password, d.SSLMode,
+	)
+}
+
+// MigrateDSN returns the PostgreSQL URL used by golang-migrate.
+func (d DatabaseConfig) MigrateDSN() string {
+	return fmt.Sprintf(
+		"postgres://%s:%s@%s:%d/%s?sslmode=%s",
+		d.User, d.Password, d.Host, d.Port, d.Name, d.SSLMode,
 	)
 }
 

--- a/backend/internal/api/middleware/logging.go
+++ b/backend/internal/api/middleware/logging.go
@@ -1,0 +1,25 @@
+package middleware
+
+import (
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
+)
+
+// RequestLogger logs method, path, status and latency for every request.
+// Query string, user IDs and request body are intentionally omitted (GDPR / no PII).
+func RequestLogger() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		start := time.Now()
+
+		c.Next()
+
+		log.Info().
+			Str("method", c.Request.Method).
+			Str("path", c.Request.URL.Path). // no RawQuery — may contain codes
+			Int("status", c.Writer.Status()).
+			Dur("latency", time.Since(start)).
+			Msg("request")
+	}
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -20,10 +20,11 @@ func NewRouter(cfg *config.Config, jwtSvc *service.JWTService, h *handlers.Handl
 
 	r := gin.New()
 	r.Use(gin.Recovery())
+	r.Use(middleware.RequestLogger())
 	r.Use(middleware.OptionalAuth(jwtSvc))
 
 	strictHandler := generated.NewStrictHandler(h, nil)
-	generated.RegisterHandlers(r, strictHandler)
+	generated.RegisterHandlers(r.Group("/api/v1"), strictHandler)
 
 	return r
 }


### PR DESCRIPTION
## What was done?

Three backend fixes — all blocking manual testing.

## Fixes

### 1. Missing `/api/v1` prefix (`router.go`)
```go
// before
generated.RegisterHandlers(r, strictHandler)

// after
generated.RegisterHandlers(r.Group("/api/v1"), strictHandler)
```
All API endpoints were registered without the prefix and returned 404.

### 2. No request logging (`middleware/logging.go` + `router.go`)
New `RequestLogger()` middleware logs every request with zerolog:
```
{"level":"info","method":"GET","path":"/api/v1/tournaments","status":200,"latency":3.2ms}
```
Logged: method, path, status, latency.
Not logged (GDPR / no PII): query string, user ID, request body.

### 3. MigrateDSN missing from config (`config.go` + `root.go`)
`DSN()` returns GORM key=value format; `golang-migrate` requires a `postgres://` URL.
`MigrateDSN()` was described in PR #30 but never committed — added here permanently.

## Verification

```bash
curl http://localhost:8080/api/v1/tournaments
# → {"past":[],"upcoming":[]}   (was 404 before)
# → log line: method=GET path=/api/v1/tournaments status=200 latency=3ms
```

## Checklist
- [x] `go build ./...` passes
- [x] Routes show `/api/v1/...` in GIN-debug output
- [x] Request log line appears after each call
- [x] No secrets / PII in logs
- [x] CLAUDE.md rules followed

Closes #38