### PR TITLE
feat(frontend): table management + photo upload + QR export + rater registration (Issue #18)

### DIFF
--- a/backend/internal/domain/tournament.go
+++ b/backend/internal/domain/tournament.go
@@ -36,6 +36,8 @@ type TournamentMembership struct {
 	JoinedAt     time.Time
 }
 
+func (TournamentMembership) TableName() string { return "tournament_members" }
+
 // TournamentRepository defines data access for tournaments.
 type TournamentRepository interface {
 	FindBySlug(ctx context.Context, slug string) (*Tournament, error)

--- a/frontend/src/api/hooks/useRaters.ts
+++ b/frontend/src/api/hooks/useRaters.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/api/client';
+import type { components } from '@/api/generated/api';
+
+export type Rater = components['schemas']['Rater'];
+export type CreateRaterRequest = components['schemas']['CreateRaterRequest'];
+
+export function useListRaters(slug: string) {
+  return useQuery<Rater[]>({
+    queryKey: ['raters', slug],
+    queryFn: () => apiClient.get(`/tournaments/${slug}/raters`).then((r) => r.data),
+    enabled: !!slug,
+  });
+}
+
+export function useCreateRater(slug: string) {
+  const qc = useQueryClient();
+  return useMutation<Rater, Error, CreateRaterRequest>({
+    mutationFn: (body) =>
+      apiClient.post(`/tournaments/${slug}/raters`, body).then((r) => r.data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['raters', slug] }),
+  });
+}

--- a/frontend/src/api/hooks/useTables.ts
+++ b/frontend/src/api/hooks/useTables.ts
@@ -1,0 +1,75 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/api/client';
+import type { components } from '@/api/generated/api';
+
+export type TableSummary = components['schemas']['TableSummary'];
+export type UpdateTableRequest = components['schemas']['UpdateTableRequest'];
+
+export function useListTables(slug: string) {
+  return useQuery<TableSummary[]>({
+    queryKey: ['tables', slug],
+    queryFn: () => apiClient.get(`/tournaments/${slug}/tables`).then((r) => r.data),
+    enabled: !!slug,
+  });
+}
+
+export function useCreateTables(slug: string) {
+  const qc = useQueryClient();
+  return useMutation<TableSummary[], Error, void>({
+    mutationFn: () => apiClient.post(`/tournaments/${slug}/tables`).then((r) => r.data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['tables', slug] }),
+  });
+}
+
+export function useUpdateTable(slug: string, number: number) {
+  const qc = useQueryClient();
+  return useMutation<TableSummary, Error, UpdateTableRequest>({
+    mutationFn: (body) =>
+      apiClient.put(`/tournaments/${slug}/tables/${number}`, body).then((r) => r.data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['tables', slug] }),
+  });
+}
+
+export function useUploadPhoto(slug: string, tableNumber: number) {
+  const qc = useQueryClient();
+  return useMutation<void, Error, FormData>({
+    mutationFn: (formData) =>
+      apiClient.post(`/tournaments/${slug}/tables/${tableNumber}/photos`, formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['tables', slug] }),
+  });
+}
+
+export function useDeletePhoto(slug: string) {
+  const qc = useQueryClient();
+  return useMutation<void, Error, string>({
+    mutationFn: (photoId) => apiClient.delete(`/photos/${photoId}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['tables', slug] }),
+  });
+}
+
+export function useGenerateQRCode(slug: string, tableNumber: number) {
+  const qc = useQueryClient();
+  return useMutation<void, Error, void>({
+    mutationFn: () => apiClient.post(`/tournaments/${slug}/tables/${tableNumber}/qrcode`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['tables', slug] }),
+  });
+}
+
+export function useGenerateAllQRCodes(slug: string) {
+  return useMutation<Blob, Error, void>({
+    mutationFn: () =>
+      apiClient
+        .post(`/tournaments/${slug}/qrcodes`, null, { responseType: 'blob' })
+        .then((r) => r.data as Blob),
+    onSuccess: (blob) => {
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `qrcodes-${slug}.pdf`;
+      a.click();
+      URL.revokeObjectURL(url);
+    },
+  });
+}

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -167,6 +167,35 @@
     "uploading": "Wird hochgeladen...",
     "delete_confirm": "Dieses Foto löschen?"
   },
+  "table_mgmt": {
+    "title": "Tische — {{name}}",
+    "create_tables": "Tische erstellen",
+    "create_tables_hint": "Erstellt alle {{count}} Tische für dieses Turnier.",
+    "create_tables_success": "Tische erstellt.",
+    "no_tables": "Noch keine Tische vorhanden.",
+    "table_number": "Tisch {{number}}",
+    "name_label": "Name (optional)",
+    "name_placeholder": "z. B. Alpenpass",
+    "description_label": "Beschreibung (optional)",
+    "save": "Speichern",
+    "qr_generate": "QR generieren",
+    "qr_download": "QR herunterladen",
+    "qr_export_all": "Alle QR-Codes exportieren (PDF)",
+    "qr_generating": "Wird generiert...",
+    "back_to_tournament": "Zurück zum Turnier"
+  },
+  "rater": {
+    "section_title": "Teilnehmer",
+    "no_raters": "Noch keine Teilnehmer registriert.",
+    "nickname_label": "Spitzname",
+    "nickname_placeholder": "z. B. Thorbjörn42",
+    "code_label": "Code (optional, 4–6 Ziffern)",
+    "code_placeholder": "Wird automatisch generiert",
+    "add_button": "Teilnehmer hinzufügen",
+    "added": "Teilnehmer hinzugefügt.",
+    "error_add": "Teilnehmer konnte nicht hinzugefügt werden.",
+    "code_hint": "Code: {{code}}"
+  },
   "results": {
     "title": "Ergebnisse",
     "rank": "Rang",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -167,6 +167,35 @@
     "uploading": "Uploading...",
     "delete_confirm": "Delete this photo?"
   },
+  "table_mgmt": {
+    "title": "Tables — {{name}}",
+    "create_tables": "Create Tables",
+    "create_tables_hint": "Creates all {{count}} tables for this tournament.",
+    "create_tables_success": "Tables created.",
+    "no_tables": "No tables yet.",
+    "table_number": "Table {{number}}",
+    "name_label": "Name (optional)",
+    "name_placeholder": "e.g. Alpine Pass",
+    "description_label": "Description (optional)",
+    "save": "Save",
+    "qr_generate": "Generate QR",
+    "qr_download": "Download QR",
+    "qr_export_all": "Export all QR codes (PDF)",
+    "qr_generating": "Generating...",
+    "back_to_tournament": "Back to Tournament"
+  },
+  "rater": {
+    "section_title": "Raters",
+    "no_raters": "No raters registered yet.",
+    "nickname_label": "Nickname",
+    "nickname_placeholder": "e.g. Thorbjörn42",
+    "code_label": "Code (optional, 4–6 digits)",
+    "code_placeholder": "Auto-generated if empty",
+    "add_button": "Add Rater",
+    "added": "Rater added.",
+    "error_add": "Could not add rater.",
+    "code_hint": "Code: {{code}}"
+  },
   "results": {
     "title": "Results",
     "rank": "Rank",

--- a/frontend/src/pages/dashboard/TableManagementPage.tsx
+++ b/frontend/src/pages/dashboard/TableManagementPage.tsx
@@ -1,16 +1,386 @@
-import { useParams } from 'react-router-dom';
+import { useRef, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { useTournament } from '@/api/hooks/useTournaments';
+import {
+  useListTables,
+  useCreateTables,
+  useUpdateTable,
+  useUploadPhoto,
+  useDeletePhoto,
+  useGenerateQRCode,
+  useGenerateAllQRCodes,
+  type TableSummary,
+} from '@/api/hooks/useTables';
+import { useListRaters, useCreateRater } from '@/api/hooks/useRaters';
 
 export function TableManagementPage() {
-  const { slug } = useParams<{ slug: string }>();
+  const { slug = '' } = useParams<{ slug: string }>();
   const { t } = useTranslation();
+  const { data: tournament } = useTournament(slug);
+  const { data: tables, isLoading } = useListTables(slug);
+  const createTables = useCreateTables(slug);
+  const exportPDF = useGenerateAllQRCodes(slug);
+
+  if (isLoading) {
+    return <p className="text-sm" style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}>{t('common.loading')}</p>;
+  }
+
+  const hasTables = tables && tables.length > 0;
 
   return (
-    <div>
-      <h1 className="font-heading text-2xl font-bold mb-6">{slug}</h1>
-      <p className="text-sm" style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}>
-        {t('common.loading')}
-      </p>
+    <div className="space-y-8 max-w-3xl">
+      {/* Header */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <Link
+            to={`/dashboard/tournaments/${slug}`}
+            className="text-xs hover:underline mb-1 block"
+            style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}
+          >
+            ← {t('table_mgmt.back_to_tournament')}
+          </Link>
+          <h1 className="font-heading text-2xl font-bold">
+            {t('table_mgmt.title', { name: tournament?.name ?? slug })}
+          </h1>
+        </div>
+
+        {hasTables && (
+          <button
+            onClick={() => exportPDF.mutate()}
+            disabled={exportPDF.isPending}
+            className="text-sm px-4 py-2 rounded border font-medium"
+            style={{ borderColor: 'var(--color-accent)', color: 'var(--color-accent)' }}
+          >
+            {exportPDF.isPending ? t('common.loading') : t('table_mgmt.qr_export_all')}
+          </button>
+        )}
+      </div>
+
+      {/* Create tables CTA */}
+      {!hasTables && (
+        <div
+          className="p-6 rounded text-center space-y-3"
+          style={{ backgroundColor: 'var(--color-surface)' }}
+        >
+          <p className="text-sm" style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}>
+            {t('table_mgmt.create_tables_hint', { count: tournament?.table_count ?? '?' })}
+          </p>
+          <button
+            onClick={() => createTables.mutate()}
+            disabled={createTables.isPending}
+            className="px-6 py-2 rounded text-sm font-medium"
+            style={{ backgroundColor: 'var(--color-primary)', color: 'var(--color-background)' }}
+          >
+            {createTables.isPending ? t('common.loading') : t('table_mgmt.create_tables')}
+          </button>
+        </div>
+      )}
+
+      {/* Table list */}
+      {hasTables && (
+        <div className="space-y-4">
+          {tables.map((table) => (
+            <TableCard key={table.id} slug={slug} table={table} />
+          ))}
+        </div>
+      )}
+
+      {/* Rater management */}
+      {hasTables && <RaterSection slug={slug} />}
     </div>
+  );
+}
+
+// ── TableCard ──────────────────────────────────────────────────────────────
+
+function TableCard({ slug, table }: { slug: string; table: TableSummary }) {
+  const { t } = useTranslation();
+  const updateTable = useUpdateTable(slug, table.number);
+  const uploadPhoto = useUploadPhoto(slug, table.number);
+  const deletePhoto = useDeletePhoto(slug);
+  const generateQR = useGenerateQRCode(slug, table.number);
+
+  const [name, setName] = useState(table.name ?? '');
+  const [description, setDescription] = useState(table.description ?? '');
+  const [dirty, setDirty] = useState(false);
+  const fileRefs = {
+    general: useRef<HTMLInputElement>(null),
+    zone_a:  useRef<HTMLInputElement>(null),
+    zone_b:  useRef<HTMLInputElement>(null),
+  };
+
+  const handleSave = () => {
+    updateTable.mutate({ name: name || null, description: description || null });
+    setDirty(false);
+  };
+
+  const handleUpload = async (category: 'general' | 'zone_a' | 'zone_b', file: File) => {
+    const fd = new FormData();
+    fd.append('photo', file);
+    fd.append('category', category);
+    await uploadPhoto.mutateAsync(fd);
+  };
+
+  const categories: Array<{ key: 'general' | 'zone_a' | 'zone_b'; label: string }> = [
+    { key: 'general', label: t('photo.category_general') },
+    { key: 'zone_a',  label: t('photo.category_zone_a') },
+    { key: 'zone_b',  label: t('photo.category_zone_b') },
+  ];
+
+  return (
+    <div
+      className="rounded border p-4 space-y-4"
+      style={{
+        backgroundColor: 'var(--color-surface)',
+        borderColor: 'color-mix(in srgb, var(--color-primary) 20%, transparent)',
+      }}
+    >
+      {/* Title row */}
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <h2 className="font-heading font-bold text-lg">
+          {t('table_mgmt.table_number', { number: table.number })}
+          {table.name && <span className="ml-2 text-base font-normal">— {table.name}</span>}
+        </h2>
+
+        <div className="flex gap-2">
+          {table.qr_code_url ? (
+            <a
+              href={table.qr_code_url}
+              target="_blank"
+              rel="noreferrer"
+              className="text-xs px-3 py-1 rounded border font-medium"
+              style={{ borderColor: 'var(--color-primary)', color: 'var(--color-primary)' }}
+            >
+              {t('table_mgmt.qr_download')}
+            </a>
+          ) : (
+            <button
+              onClick={() => generateQR.mutate()}
+              disabled={generateQR.isPending}
+              className="text-xs px-3 py-1 rounded border font-medium"
+              style={{ borderColor: 'var(--color-primary)', color: 'var(--color-primary)' }}
+            >
+              {generateQR.isPending ? t('table_mgmt.qr_generating') : t('table_mgmt.qr_generate')}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Name + description fields */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <div>
+          <label className="block text-xs font-medium mb-1">{t('table_mgmt.name_label')}</label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => { setName(e.target.value); setDirty(true); }}
+            placeholder={t('table_mgmt.name_placeholder')}
+            className="w-full px-3 py-1.5 rounded text-sm border"
+            style={{
+              backgroundColor: 'var(--color-background)',
+              borderColor: 'color-mix(in srgb, var(--color-primary) 30%, transparent)',
+              color: 'var(--color-text)',
+            }}
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium mb-1">{t('table_mgmt.description_label')}</label>
+          <input
+            type="text"
+            value={description}
+            onChange={(e) => { setDescription(e.target.value); setDirty(true); }}
+            placeholder=""
+            className="w-full px-3 py-1.5 rounded text-sm border"
+            style={{
+              backgroundColor: 'var(--color-background)',
+              borderColor: 'color-mix(in srgb, var(--color-primary) 30%, transparent)',
+              color: 'var(--color-text)',
+            }}
+          />
+        </div>
+      </div>
+
+      {dirty && (
+        <button
+          onClick={handleSave}
+          disabled={updateTable.isPending}
+          className="text-xs px-4 py-1.5 rounded font-medium"
+          style={{ backgroundColor: 'var(--color-primary)', color: 'var(--color-background)' }}
+        >
+          {updateTable.isPending ? t('common.loading') : t('table_mgmt.save')}
+        </button>
+      )}
+
+      {/* Photos by category */}
+      <div className="space-y-3">
+        {categories.map(({ key, label }) => {
+          const photos = table.photos.filter((p) => p.category === key);
+          return (
+            <div key={key}>
+              <p className="text-xs font-medium mb-1.5">{label}</p>
+              <div className="flex flex-wrap gap-2 items-center">
+                {photos.map((photo) => (
+                  <div key={photo.id} className="relative group">
+                    <img
+                      src={photo.thumbnail_url ?? photo.url}
+                      alt=""
+                      className="h-16 w-16 object-cover rounded"
+                    />
+                    <button
+                      onClick={() => {
+                        if (window.confirm(t('photo.delete_confirm'))) {
+                          deletePhoto.mutate(photo.id.toString());
+                        }
+                      }}
+                      className="absolute -top-1.5 -right-1.5 h-5 w-5 rounded-full text-xs flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+                      style={{ backgroundColor: '#dc2626', color: 'white' }}
+                      aria-label="Delete photo"
+                    >
+                      ×
+                    </button>
+                  </div>
+                ))}
+
+                {/* Upload button */}
+                <button
+                  onClick={() => fileRefs[key].current?.click()}
+                  disabled={uploadPhoto.isPending}
+                  className="h-16 w-16 rounded border-2 border-dashed text-xs flex items-center justify-center"
+                  style={{ borderColor: 'color-mix(in srgb, var(--color-primary) 40%, transparent)', color: 'color-mix(in srgb, var(--color-text) 50%, transparent)' }}
+                  aria-label={t('photo.tap_to_upload')}
+                >
+                  {uploadPhoto.isPending ? '…' : '+'}
+                </button>
+                <input
+                  ref={fileRefs[key]}
+                  type="file"
+                  accept="image/*"
+                  className="sr-only"
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (file) handleUpload(key, file);
+                    e.target.value = '';
+                  }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ── RaterSection ───────────────────────────────────────────────────────────
+
+function RaterSection({ slug }: { slug: string }) {
+  const { t } = useTranslation();
+  const { data: raters, isLoading } = useListRaters(slug);
+  const createRater = useCreateRater(slug);
+
+  const [nickname, setNickname] = useState('');
+  const [code, setCode] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleAdd = async () => {
+    if (!nickname.trim()) return;
+    setError(null);
+    try {
+      await createRater.mutateAsync({
+        nickname: nickname.trim(),
+        code: code.trim() || undefined,
+      });
+      setNickname('');
+      setCode('');
+    } catch {
+      setError(t('rater.error_add'));
+    }
+  };
+
+  return (
+    <section aria-labelledby="rater-heading" className="space-y-4">
+      <h2 id="rater-heading" className="font-heading text-xl font-bold">
+        {t('rater.section_title')}
+      </h2>
+
+      {/* Add rater form */}
+      <div className="flex flex-wrap gap-3 items-end">
+        <div>
+          <label className="block text-xs font-medium mb-1">{t('rater.nickname_label')}</label>
+          <input
+            type="text"
+            value={nickname}
+            onChange={(e) => setNickname(e.target.value)}
+            placeholder={t('rater.nickname_placeholder')}
+            className="px-3 py-1.5 rounded text-sm border"
+            style={{
+              backgroundColor: 'var(--color-surface)',
+              borderColor: 'color-mix(in srgb, var(--color-primary) 30%, transparent)',
+              color: 'var(--color-text)',
+            }}
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium mb-1">{t('rater.code_label')}</label>
+          <input
+            type="text"
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            placeholder={t('rater.code_placeholder')}
+            maxLength={6}
+            className="px-3 py-1.5 rounded text-sm border w-36"
+            style={{
+              backgroundColor: 'var(--color-surface)',
+              borderColor: 'color-mix(in srgb, var(--color-primary) 30%, transparent)',
+              color: 'var(--color-text)',
+            }}
+          />
+        </div>
+        <button
+          onClick={handleAdd}
+          disabled={createRater.isPending || !nickname.trim()}
+          className="px-4 py-1.5 rounded text-sm font-medium"
+          style={{ backgroundColor: 'var(--color-primary)', color: 'var(--color-background)' }}
+        >
+          {createRater.isPending ? t('common.loading') : t('rater.add_button')}
+        </button>
+        {error && <p className="text-xs self-end" style={{ color: '#dc2626' }}>{error}</p>}
+      </div>
+
+      {/* Rater list */}
+      {isLoading ? (
+        <p className="text-sm" style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}>{t('common.loading')}</p>
+      ) : raters && raters.length > 0 ? (
+        <div
+          className="rounded border overflow-hidden"
+          style={{ borderColor: 'color-mix(in srgb, var(--color-primary) 20%, transparent)' }}
+        >
+          <table className="w-full text-sm">
+            <thead>
+              <tr style={{ backgroundColor: 'color-mix(in srgb, var(--color-primary) 8%, transparent)' }}>
+                <th className="text-left px-4 py-2 font-medium">{t('rater.nickname_label')}</th>
+                <th className="text-left px-4 py-2 font-medium">{t('rater.code_label').split(' ')[0]}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {raters.map((rater, i) => (
+                <tr
+                  key={rater.id}
+                  style={{ backgroundColor: i % 2 === 0 ? 'transparent' : 'color-mix(in srgb, var(--color-primary) 4%, transparent)' }}
+                >
+                  <td className="px-4 py-2">{rater.nickname}</td>
+                  <td className="px-4 py-2 font-mono text-xs">—</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p className="text-sm" style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}>
+          {t('rater.no_raters')}
+        </p>
+      )}
+    </section>
   );
 }


### PR DESCRIPTION
## What was done?
Implemented the full table management page for organizers/helpers.

## Why?
Issue #18 — Epic 2 (US-10–US-14): table creation, photo management, QR codes, rater registration.

## Changes

### Backend fix
- `domain/tournament.go`: added `TableName() string { return "tournament_members" }` to `TournamentMembership` — GORM was auto-pluralizing to `tournament_memberships` which doesn't exist, causing a 500 on tournament creation

### Frontend
- **`useTables.ts`**: `useListTables`, `useCreateTables`, `useUpdateTable`, `useUploadPhoto`, `useDeletePhoto`, `useGenerateQRCode`, `useGenerateAllQRCodes` (triggers PDF download)
- **`useRaters.ts`**: `useListRaters`, `useCreateRater`
- **`TableManagementPage`**:
  - Create tables CTA (shown when no tables exist yet)
  - Per-table card: edit name + description, generate/download QR code
  - Photo upload per category (General / Zone A / Zone B) with hover-delete
  - "Export all QR codes (PDF)" button
  - Rater section: add rater by nickname + optional 4–6 digit code, list view
- i18n EN + DE: `table_mgmt` and `rater` sections

## Checklist
- [x] TypeScript: no errors
- [x] No secrets in code
- [x] CLAUDE.md rules followed

Closes #18