### PR TITLE
fix(frontend): tournament detail page + rater management as own page

### DIFF
--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -39,7 +39,10 @@
     "tables_count": "{{count}} Tische",
     "view_tables": "Tische ansehen",
     "event_date": "Veranstaltungsdatum",
-    "location": "Ort"
+    "location": "Ort",
+    "links_disclaimer": "Wir übernehmen keine Verantwortung für externe Inhalte.",
+    "no_tables": "Es wurden noch keine Tische angelegt.",
+    "rate_table": "Bewerten"
   },
   "table": {
     "number": "Tisch {{number}}",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -39,7 +39,10 @@
     "tables_count": "{{count}} tables",
     "view_tables": "View Tables",
     "event_date": "Event date",
-    "location": "Location"
+    "location": "Location",
+    "links_disclaimer": "We are not responsible for the content of external links.",
+    "no_tables": "No tables have been set up yet.",
+    "rate_table": "Rate"
   },
   "table": {
     "number": "Table {{number}}",

--- a/frontend/src/pages/TournamentPage.tsx
+++ b/frontend/src/pages/TournamentPage.tsx
@@ -1,14 +1,170 @@
-import { useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { AppLayout } from '@/components/layout/AppLayout';
+import { useTournament } from '@/api/hooks/useTournaments';
+import type { TableSummary } from '@/api/hooks/useTables';
 
 export function TournamentPage() {
-  const { slug } = useParams<{ slug: string }>();
+  const { slug = '' } = useParams<{ slug: string }>();
+  const { t } = useTranslation();
+  const { data: tournament, isLoading, isError } = useTournament(slug);
 
   return (
     <AppLayout>
-      <main className="container mx-auto px-4 py-8">
-        <p className="text-sm text-muted-foreground">Tournament: {slug}</p>
+      <main className="container mx-auto px-4 py-8 max-w-3xl">
+        {isLoading && (
+          <p className="text-sm" style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}>
+            {t('common.loading')}
+          </p>
+        )}
+
+        {isError && (
+          <p className="text-sm" style={{ color: '#dc2626' }}>{t('errors.not_found')}</p>
+        )}
+
+        {tournament && (
+          <div className="space-y-8">
+
+            {/* Header */}
+            <div className="space-y-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <span
+                  className="text-xs px-2 py-0.5 rounded font-medium uppercase tracking-wide"
+                  style={{ backgroundColor: 'color-mix(in srgb, var(--color-primary) 15%, transparent)', color: 'var(--color-primary)' }}
+                >
+                  {t(`tournament.type_${tournament.type}`)}
+                </span>
+                <span
+                  className="text-xs px-2 py-0.5 rounded font-medium"
+                  style={{ backgroundColor: 'color-mix(in srgb, var(--color-text) 10%, transparent)', color: 'color-mix(in srgb, var(--color-text) 70%, transparent)' }}
+                >
+                  {t(`tournament.status_${tournament.status}`)}
+                </span>
+              </div>
+              <h1 className="font-heading text-3xl font-bold">{tournament.name}</h1>
+            </div>
+
+            {/* Meta info */}
+            {(tournament.event_date || tournament.location) && (
+              <div className="flex flex-wrap gap-4 text-sm" style={{ color: 'color-mix(in srgb, var(--color-text) 70%, transparent)' }}>
+                {tournament.event_date && (
+                  <span>
+                    <span className="font-medium">{t('tournament.event_date')}:</span>{' '}
+                    {new Date(tournament.event_date).toLocaleDateString()}
+                  </span>
+                )}
+                {tournament.location && (
+                  <span>
+                    <span className="font-medium">{t('tournament.location')}:</span>{' '}
+                    {tournament.location}
+                  </span>
+                )}
+              </div>
+            )}
+
+            {/* Description */}
+            {tournament.description && (
+              <div
+                className="p-4 rounded text-sm leading-relaxed whitespace-pre-wrap"
+                style={{ backgroundColor: 'var(--color-surface)' }}
+              >
+                {tournament.description}
+              </div>
+            )}
+
+            {/* External links */}
+            {tournament.links && tournament.links.length > 0 && (
+              <div className="space-y-2">
+                <div className="flex flex-wrap gap-2">
+                  {tournament.links.map((link, i) => (
+                    <a
+                      key={i}
+                      href={link.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 text-sm px-3 py-1.5 rounded border"
+                      style={{ borderColor: 'var(--color-primary)', color: 'var(--color-primary)' }}
+                    >
+                      {link.label || link.url}
+                      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5">
+                        <path d="M5 2H2a1 1 0 00-1 1v7a1 1 0 001 1h7a1 1 0 001-1V7M7 1h4m0 0v4m0-4L5 7" />
+                      </svg>
+                    </a>
+                  ))}
+                </div>
+                <p className="text-xs" style={{ color: 'color-mix(in srgb, var(--color-text) 50%, transparent)' }}>
+                  {t('tournament.links_disclaimer')}
+                </p>
+              </div>
+            )}
+
+            {/* Tables */}
+            <div className="space-y-3">
+              <h2 className="font-heading text-xl font-bold">
+                {t('tournament.tables_count', { count: tournament.table_count })}
+              </h2>
+
+              {(!tournament.tables || tournament.tables.length === 0) ? (
+                <p className="text-sm" style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}>
+                  {t('tournament.no_tables')}
+                </p>
+              ) : (
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  {tournament.tables.map((table) => (
+                    <TableCard key={table.id} slug={slug} table={table} rateLabel={t('tournament.rate_table')} tableLabel={t('table.number', { number: table.number })} />
+                  ))}
+                </div>
+              )}
+            </div>
+
+          </div>
+        )}
       </main>
     </AppLayout>
+  );
+}
+
+function TableCard({ slug, table, rateLabel, tableLabel }: {
+  slug: string;
+  table: TableSummary;
+  rateLabel: string;
+  tableLabel: string;
+}) {
+  const firstPhoto = table.photos?.[0];
+  const thumbUrl = firstPhoto?.thumbnail_url ?? firstPhoto?.url;
+
+  return (
+    <div
+      className="rounded border overflow-hidden"
+      style={{
+        backgroundColor: 'var(--color-surface)',
+        borderColor: 'color-mix(in srgb, var(--color-primary) 20%, transparent)',
+      }}
+    >
+      {thumbUrl && (
+        <img
+          src={thumbUrl}
+          alt=""
+          className="w-full h-32 object-cover"
+        />
+      )}
+      <div className="p-3 flex items-center justify-between gap-2">
+        <div className="min-w-0">
+          <p className="font-medium text-sm truncate">{tableLabel}</p>
+          {table.name && (
+            <p className="text-xs truncate" style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}>
+              {table.name}
+            </p>
+          )}
+        </div>
+        <Link
+          to={`/rate/${slug}/${table.number}`}
+          className="shrink-0 inline-flex items-center justify-center text-xs px-3 py-1.5 rounded font-medium"
+          style={{ backgroundColor: 'var(--color-primary)', color: 'var(--color-background)' }}
+        >
+          {rateLabel}
+        </Link>
+      </div>
+    </div>
   );
 }

--- a/frontend/src/pages/dashboard/MyTournamentsPage.tsx
+++ b/frontend/src/pages/dashboard/MyTournamentsPage.tsx
@@ -56,6 +56,13 @@ export function MyTournamentsPage() {
                   {t('dashboard.tables')}
                 </Link>
                 <Link
+                  to={`/dashboard/tournaments/${m.tournament_slug}/raters`}
+                  className="inline-flex items-center justify-center text-xs px-3 py-1 rounded border"
+                  style={{ borderColor: 'var(--color-primary)', color: 'var(--color-primary)' }}
+                >
+                  {t('rater.section_title')}
+                </Link>
+                <Link
                   to={`/dashboard/tournaments/${m.tournament_slug}/results`}
                   className="inline-flex items-center justify-center text-xs px-3 py-1 rounded border"
                   style={{ borderColor: 'var(--color-accent)', color: 'var(--color-accent)' }}

--- a/frontend/src/pages/dashboard/RaterManagementPage.tsx
+++ b/frontend/src/pages/dashboard/RaterManagementPage.tsx
@@ -1,0 +1,131 @@
+import { useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useTournament } from '@/api/hooks/useTournaments';
+import { useListRaters, useCreateRater } from '@/api/hooks/useRaters';
+
+export function RaterManagementPage() {
+  const { slug = '' } = useParams<{ slug: string }>();
+  const { t } = useTranslation();
+  const { data: tournament } = useTournament(slug);
+  const { data: raters, isLoading } = useListRaters(slug);
+  const createRater = useCreateRater(slug);
+
+  const [nickname, setNickname] = useState('');
+  const [code, setCode] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleAdd = async () => {
+    if (!nickname.trim()) return;
+    setError(null);
+    try {
+      await createRater.mutateAsync({
+        nickname: nickname.trim(),
+        code: code.trim() || undefined,
+      });
+      setNickname('');
+      setCode('');
+    } catch {
+      setError(t('rater.error_add'));
+    }
+  };
+
+  return (
+    <div className="space-y-6 max-w-2xl">
+      {/* Header */}
+      <div>
+        <Link
+          to={`/dashboard/tournaments/${slug}`}
+          className="text-xs hover:underline mb-1 block"
+          style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}
+        >
+          ← {t('table_mgmt.back_to_tournament')}
+        </Link>
+        <h1 className="font-heading text-2xl font-bold">
+          {t('rater.section_title')} — {tournament?.name ?? slug}
+        </h1>
+      </div>
+
+      {/* Add rater form */}
+      <div className="flex flex-wrap gap-3 items-end">
+        <div>
+          <label className="block text-xs font-medium mb-1">{t('rater.nickname_label')}</label>
+          <input
+            type="text"
+            value={nickname}
+            onChange={(e) => setNickname(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleAdd()}
+            placeholder={t('rater.nickname_placeholder')}
+            className="px-3 py-1.5 rounded text-sm border"
+            style={{
+              backgroundColor: 'var(--color-surface)',
+              borderColor: 'color-mix(in srgb, var(--color-primary) 30%, transparent)',
+              color: 'var(--color-text)',
+            }}
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium mb-1">{t('rater.code_label')}</label>
+          <input
+            type="text"
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            placeholder={t('rater.code_placeholder')}
+            maxLength={6}
+            className="px-3 py-1.5 rounded text-sm border w-36"
+            style={{
+              backgroundColor: 'var(--color-surface)',
+              borderColor: 'color-mix(in srgb, var(--color-primary) 30%, transparent)',
+              color: 'var(--color-text)',
+            }}
+          />
+        </div>
+        <button
+          onClick={handleAdd}
+          disabled={createRater.isPending || !nickname.trim()}
+          className="inline-flex items-center justify-center px-4 py-1.5 rounded text-sm font-medium"
+          style={{ backgroundColor: 'var(--color-primary)', color: 'var(--color-background)' }}
+        >
+          {createRater.isPending ? t('common.loading') : t('rater.add_button')}
+        </button>
+        {error && <p className="text-xs self-end" style={{ color: '#dc2626' }}>{error}</p>}
+      </div>
+
+      {/* Rater list */}
+      {isLoading ? (
+        <p className="text-sm" style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}>
+          {t('common.loading')}
+        </p>
+      ) : raters && raters.length > 0 ? (
+        <div
+          className="rounded border overflow-hidden"
+          style={{ borderColor: 'color-mix(in srgb, var(--color-primary) 20%, transparent)' }}
+        >
+          <table className="w-full text-sm">
+            <thead>
+              <tr style={{ backgroundColor: 'color-mix(in srgb, var(--color-primary) 8%, transparent)' }}>
+                <th className="text-left px-4 py-2 font-medium">{t('rater.nickname_label')}</th>
+                <th className="text-left px-4 py-2 font-medium">{t('rater.code_label').split(' ')[0]}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {raters.map((rater, i) => (
+                <tr
+                  key={rater.id}
+                  style={{ backgroundColor: i % 2 === 0 ? 'transparent' : 'color-mix(in srgb, var(--color-primary) 4%, transparent)' }}
+                >
+                  <td className="px-4 py-2">{rater.nickname}</td>
+                  <td className="px-4 py-2 font-mono text-xs">—</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p className="text-sm" style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}>
+          {t('rater.no_raters')}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/dashboard/TableManagementPage.tsx
+++ b/frontend/src/pages/dashboard/TableManagementPage.tsx
@@ -12,7 +12,6 @@ import {
   useGenerateAllQRCodes,
   type TableSummary,
 } from '@/api/hooks/useTables';
-import { useListRaters, useCreateRater } from '@/api/hooks/useRaters';
 
 export function TableManagementPage() {
   const { slug = '' } = useParams<{ slug: string }>();
@@ -86,8 +85,6 @@ export function TableManagementPage() {
         </div>
       )}
 
-      {/* Rater management */}
-      {hasTables && <RaterSection slug={slug} />}
     </div>
   );
 }
@@ -272,115 +269,3 @@ function TableCard({ slug, table }: { slug: string; table: TableSummary }) {
   );
 }
 
-// ── RaterSection ───────────────────────────────────────────────────────────
-
-function RaterSection({ slug }: { slug: string }) {
-  const { t } = useTranslation();
-  const { data: raters, isLoading } = useListRaters(slug);
-  const createRater = useCreateRater(slug);
-
-  const [nickname, setNickname] = useState('');
-  const [code, setCode] = useState('');
-  const [error, setError] = useState<string | null>(null);
-
-  const handleAdd = async () => {
-    if (!nickname.trim()) return;
-    setError(null);
-    try {
-      await createRater.mutateAsync({
-        nickname: nickname.trim(),
-        code: code.trim() || undefined,
-      });
-      setNickname('');
-      setCode('');
-    } catch {
-      setError(t('rater.error_add'));
-    }
-  };
-
-  return (
-    <section aria-labelledby="rater-heading" className="space-y-4">
-      <h2 id="rater-heading" className="font-heading text-xl font-bold">
-        {t('rater.section_title')}
-      </h2>
-
-      {/* Add rater form */}
-      <div className="flex flex-wrap gap-3 items-end">
-        <div>
-          <label className="block text-xs font-medium mb-1">{t('rater.nickname_label')}</label>
-          <input
-            type="text"
-            value={nickname}
-            onChange={(e) => setNickname(e.target.value)}
-            placeholder={t('rater.nickname_placeholder')}
-            className="px-3 py-1.5 rounded text-sm border"
-            style={{
-              backgroundColor: 'var(--color-surface)',
-              borderColor: 'color-mix(in srgb, var(--color-primary) 30%, transparent)',
-              color: 'var(--color-text)',
-            }}
-          />
-        </div>
-        <div>
-          <label className="block text-xs font-medium mb-1">{t('rater.code_label')}</label>
-          <input
-            type="text"
-            value={code}
-            onChange={(e) => setCode(e.target.value)}
-            placeholder={t('rater.code_placeholder')}
-            maxLength={6}
-            className="px-3 py-1.5 rounded text-sm border w-36"
-            style={{
-              backgroundColor: 'var(--color-surface)',
-              borderColor: 'color-mix(in srgb, var(--color-primary) 30%, transparent)',
-              color: 'var(--color-text)',
-            }}
-          />
-        </div>
-        <button
-          onClick={handleAdd}
-          disabled={createRater.isPending || !nickname.trim()}
-          className="px-4 py-1.5 rounded text-sm font-medium"
-          style={{ backgroundColor: 'var(--color-primary)', color: 'var(--color-background)' }}
-        >
-          {createRater.isPending ? t('common.loading') : t('rater.add_button')}
-        </button>
-        {error && <p className="text-xs self-end" style={{ color: '#dc2626' }}>{error}</p>}
-      </div>
-
-      {/* Rater list */}
-      {isLoading ? (
-        <p className="text-sm" style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}>{t('common.loading')}</p>
-      ) : raters && raters.length > 0 ? (
-        <div
-          className="rounded border overflow-hidden"
-          style={{ borderColor: 'color-mix(in srgb, var(--color-primary) 20%, transparent)' }}
-        >
-          <table className="w-full text-sm">
-            <thead>
-              <tr style={{ backgroundColor: 'color-mix(in srgb, var(--color-primary) 8%, transparent)' }}>
-                <th className="text-left px-4 py-2 font-medium">{t('rater.nickname_label')}</th>
-                <th className="text-left px-4 py-2 font-medium">{t('rater.code_label').split(' ')[0]}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {raters.map((rater, i) => (
-                <tr
-                  key={rater.id}
-                  style={{ backgroundColor: i % 2 === 0 ? 'transparent' : 'color-mix(in srgb, var(--color-primary) 4%, transparent)' }}
-                >
-                  <td className="px-4 py-2">{rater.nickname}</td>
-                  <td className="px-4 py-2 font-mono text-xs">—</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      ) : (
-        <p className="text-sm" style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}>
-          {t('rater.no_raters')}
-        </p>
-      )}
-    </section>
-  );
-}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -16,6 +16,7 @@ import { ArchivedTournamentsPage } from '@/pages/dashboard/ArchivedTournamentsPa
 import { ProfilePage } from '@/pages/dashboard/ProfilePage';
 import { TournamentEditPage } from '@/pages/dashboard/TournamentEditPage';
 import { TableManagementPage } from '@/pages/dashboard/TableManagementPage';
+import { RaterManagementPage } from '@/pages/dashboard/RaterManagementPage';
 import { ResultsPage } from '@/pages/dashboard/ResultsPage';
 
 export const router = createBrowserRouter([
@@ -43,6 +44,7 @@ export const router = createBrowserRouter([
       { path: 'tournaments/new', element: <TournamentEditPage /> },
       { path: 'tournaments/:slug', element: <TournamentEditPage /> },
       { path: 'tournaments/:slug/tables', element: <TableManagementPage /> },
+      { path: 'tournaments/:slug/raters', element: <RaterManagementPage /> },
       {
         path: 'tournaments/:slug/results',
         element: (


### PR DESCRIPTION
## What was done?
Two frontend feature/fix issues from PR B.

## Changes

### #51 — Tournament detail page
`TournamentPage.tsx` was a stub (`Tournament: {slug}`). Now fully implemented:
- Name, type badge (Fantasy/Sci-Fi), status badge
- Event date + location (if set)
- Description (plain text, `whitespace-pre-wrap`)
- External links with disclaimer ("We are not responsible for external content")
- Table grid: thumbnail (first photo), table number/name, "Rate" button → `/rate/:slug/:number`
- New i18n keys: `tournament.links_disclaimer`, `tournament.no_tables`, `tournament.rate_table`

### #54 — Rater management as own page
- New `RaterManagementPage.tsx` at `/dashboard/tournaments/:slug/raters`
- "Teilnehmer" button added to each tournament row in `MyTournamentsPage`
- `RaterSection` and its imports removed from `TableManagementPage`
- Route added in `router.tsx`

## Checklist
- [x] No new dependencies
- [x] TypeScript builds without errors
- [x] No secrets in code
- [x] CLAUDE.md rules followed