### PR TITLE
feat: rater login + rating form (#19)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -18,13 +18,19 @@ apiClient.interceptors.request.use((config) => {
   return config;
 });
 
-// Handle 401: clear auth and redirect to login
+// Handle 401: clear auth and redirect to appropriate login page
 apiClient.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response?.status === 401) {
+      const role = useAuthStore.getState().role;
       useAuthStore.getState().logout();
-      window.location.href = '/login';
+      if (role === 'rater') {
+        // Raters go back to rater login — keep path so slug can be extracted if needed
+        window.location.href = '/rate-login';
+      } else {
+        window.location.href = '/login';
+      }
     }
     return Promise.reject(error);
   },

--- a/frontend/src/api/hooks/useAuth.ts
+++ b/frontend/src/api/hooks/useAuth.ts
@@ -1,0 +1,17 @@
+import { useMutation } from '@tanstack/react-query';
+import { apiClient } from '@/api/client';
+import type { components } from '@/api/generated/api';
+
+type RaterAuthRequest = components['schemas']['RaterAuthRequest'];
+
+interface AuthTokenResponse {
+  token: string;
+  refresh_token?: string;
+}
+
+export function useRaterLogin() {
+  return useMutation<AuthTokenResponse, Error, RaterAuthRequest>({
+    mutationFn: (body) =>
+      apiClient.post('/auth/rater', body).then((r) => r.data),
+  });
+}

--- a/frontend/src/api/hooks/useTables.ts
+++ b/frontend/src/api/hooks/useTables.ts
@@ -3,7 +3,25 @@ import { apiClient } from '@/api/client';
 import type { components } from '@/api/generated/api';
 
 export type TableSummary = components['schemas']['TableSummary'];
+export type TableDetail = components['schemas']['TableDetail'];
 export type UpdateTableRequest = components['schemas']['UpdateTableRequest'];
+export type CreateRatingRequest = components['schemas']['CreateRatingRequest'];
+
+export function useGetTable(slug: string, number: number | string) {
+  return useQuery<TableDetail>({
+    queryKey: ['table', slug, number],
+    queryFn: () =>
+      apiClient.get(`/tournaments/${slug}/tables/${number}`).then((r) => r.data),
+    enabled: !!slug && !!number,
+  });
+}
+
+export function useSubmitRating(slug: string, tableNumber: number | string) {
+  return useMutation<void, Error, CreateRatingRequest>({
+    mutationFn: (body) =>
+      apiClient.post(`/tournaments/${slug}/tables/${tableNumber}/ratings`, body),
+  });
+}
 
 export function useListTables(slug: string) {
   return useQuery<TableSummary[]>({

--- a/frontend/src/pages/RatePage.tsx
+++ b/frontend/src/pages/RatePage.tsx
@@ -1,19 +1,342 @@
-import { useParams } from 'react-router-dom';
-import { AppLayout } from '@/components/layout/AppLayout';
+import { useState } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { AppLayout } from '@/components/layout/AppLayout';
+import { useGetTable, useSubmitRating } from '@/api/hooks/useTables';
+import { useAuthStore } from '@/stores/authStore';
+import type { components } from '@/api/generated/api';
+
+type CriteriaKey = components['schemas']['CriteriaKey'];
+type PlayedZone = components['schemas']['PlayedZone'];
+type Photo = components['schemas']['Photo'];
+
+const GRADES = [1, 2, 3, 4, 5, 6] as const;
 
 export function RatePage() {
-  const { slug, tableNum } = useParams<{ slug: string; tableNum: string }>();
+  const { slug = '', tableNum = '' } = useParams<{ slug: string; tableNum: string }>();
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { isAuthenticated, hasRole } = useAuthStore();
+
+  const { data: table, isLoading } = useGetTable(slug, tableNum);
+  const submitRating = useSubmitRating(slug, tableNum);
+
+  const [scores, setScores] = useState<Record<string, number>>({});
+  const [playedZone, setPlayedZone] = useState<PlayedZone>('none');
+  const [comment, setComment] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+  const [alreadyRated, setAlreadyRated] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Redirect unauthenticated raters to login
+  if (!isAuthenticated() || !hasRole('rater')) {
+    return (
+      <AppLayout>
+        <main className="container mx-auto px-4 py-12 max-w-xl text-center space-y-4">
+          <p className="text-sm" style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}>
+            {t('auth.rater_login_title')}
+          </p>
+          <Link
+            to={`/rate-login/${slug}`}
+            className="inline-flex items-center justify-center px-6 py-2 rounded font-medium text-sm"
+            style={{ backgroundColor: 'var(--color-primary)', color: 'var(--color-background)' }}
+          >
+            {t('auth.login_button')}
+          </Link>
+        </main>
+      </AppLayout>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <AppLayout>
+        <main className="container mx-auto px-4 py-8">
+          <p className="text-sm" style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}>
+            {t('common.loading')}
+          </p>
+        </main>
+      </AppLayout>
+    );
+  }
+
+  if (!table) {
+    return (
+      <AppLayout>
+        <main className="container mx-auto px-4 py-8">
+          <p className="text-sm" style={{ color: '#dc2626' }}>{t('errors.not_found')}</p>
+        </main>
+      </AppLayout>
+    );
+  }
+
+  const activeCriteria = table.active_criteria as CriteriaKey[];
+  const zonePhotos = {
+    zone_a: table.photos.filter((p) => p.category === 'zone_a'),
+    zone_b: table.photos.filter((p) => p.category === 'zone_b'),
+    general: table.photos.filter((p) => p.category === 'general'),
+  };
+
+  const allScored = activeCriteria.every((c) => scores[c] !== undefined);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!allScored) return;
+    setError(null);
+    try {
+      await submitRating.mutateAsync({
+        criteria_scores: scores,
+        played_zone: playedZone,
+        comment: comment.trim() || null,
+      });
+      setSubmitted(true);
+    } catch (err: unknown) {
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      if (status === 409) {
+        setAlreadyRated(true);
+      } else {
+        setError(t('errors.generic'));
+      }
+    }
+  };
+
+  if (submitted || alreadyRated) {
+    return (
+      <AppLayout>
+        <main className="container mx-auto px-4 py-12 max-w-xl text-center space-y-4">
+          <p className="font-heading text-2xl font-bold">
+            {alreadyRated ? t('rating.already_rated') : t('rating.success')}
+          </p>
+          <Link
+            to={`/t/${slug}`}
+            className="inline-flex items-center justify-center px-6 py-2 rounded font-medium text-sm"
+            style={{ backgroundColor: 'var(--color-primary)', color: 'var(--color-background)' }}
+          >
+            {t('common.back')}
+          </Link>
+        </main>
+      </AppLayout>
+    );
+  }
 
   return (
     <AppLayout>
-      <main className="container mx-auto px-4 py-8">
-        <h1 className="font-heading text-2xl font-bold mb-4">
-          {t('rating.title')} — {t('table.number', { number: tableNum })}
-        </h1>
-        <p className="text-sm text-muted-foreground">Tournament: {slug}</p>
+      <main className="container mx-auto px-4 py-8 max-w-xl space-y-8">
+        {/* Header */}
+        <div>
+          <Link
+            to={`/t/${slug}`}
+            className="text-xs hover:underline mb-1 block"
+            style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}
+          >
+            ← {table.tournament_name}
+          </Link>
+          <h1 className="font-heading text-2xl font-bold">
+            {t('table.number', { number: table.number })}
+            {table.name && <span className="ml-2 text-base font-normal">— {table.name}</span>}
+          </h1>
+          {table.description && (
+            <p
+              className="mt-1 text-sm"
+              style={{ color: 'color-mix(in srgb, var(--color-text) 70%, transparent)' }}
+            >
+              {table.description}
+            </p>
+          )}
+        </div>
+
+        {/* General photos */}
+        {zonePhotos.general.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {zonePhotos.general.map((p) => (
+              <img
+                key={p.id}
+                src={p.url}
+                alt=""
+                className="h-28 w-28 object-cover rounded"
+              />
+            ))}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-8">
+          {/* Criteria ratings */}
+          <div className="space-y-6">
+            {activeCriteria.map((criterion) => (
+              <CriterionRow
+                key={criterion}
+                criterion={criterion}
+                value={scores[criterion]}
+                onChange={(v) => setScores((prev) => ({ ...prev, [criterion]: v }))}
+                photos={
+                  criterion === 'zone_a'
+                    ? zonePhotos.zone_a
+                    : criterion === 'zone_b'
+                    ? zonePhotos.zone_b
+                    : []
+                }
+              />
+            ))}
+          </div>
+
+          {/* Played zone */}
+          <div>
+            <p className="text-sm font-medium mb-2">{t('rating.played_zone')}</p>
+            <div className="flex flex-wrap gap-2">
+              {(['none', 'zone_a', 'zone_b'] as PlayedZone[]).map((zone) => (
+                <button
+                  key={zone}
+                  type="button"
+                  onClick={() => setPlayedZone(zone)}
+                  className="px-4 py-1.5 rounded border text-sm font-medium"
+                  style={{
+                    borderColor:
+                      playedZone === zone
+                        ? 'var(--color-primary)'
+                        : 'color-mix(in srgb, var(--color-text) 30%, transparent)',
+                    backgroundColor:
+                      playedZone === zone
+                        ? 'color-mix(in srgb, var(--color-primary) 15%, transparent)'
+                        : 'transparent',
+                    color:
+                      playedZone === zone
+                        ? 'var(--color-primary)'
+                        : 'var(--color-text)',
+                  }}
+                >
+                  {zone === 'none'
+                    ? t('rating.played_none')
+                    : zone === 'zone_a'
+                    ? t('rating.played_zone_a')
+                    : t('rating.played_zone_b')}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Comment */}
+          <div>
+            <textarea
+              value={comment}
+              onChange={(e) => setComment(e.target.value)}
+              placeholder={t('rating.comment_placeholder')}
+              maxLength={1000}
+              rows={3}
+              className="w-full px-3 py-2 rounded border text-sm resize-none"
+              style={{
+                backgroundColor: 'var(--color-surface)',
+                borderColor: 'color-mix(in srgb, var(--color-primary) 30%, transparent)',
+                color: 'var(--color-text)',
+              }}
+            />
+            <p
+              className="text-xs mt-1 text-right"
+              style={{ color: 'color-mix(in srgb, var(--color-text) 50%, transparent)' }}
+            >
+              {comment.length} / 1000
+            </p>
+          </div>
+
+          {error && <p className="text-sm" style={{ color: '#dc2626' }}>{error}</p>}
+
+          <button
+            type="submit"
+            disabled={submitRating.isPending || !allScored}
+            className="w-full py-3 rounded font-medium text-sm"
+            style={{
+              backgroundColor: 'var(--color-primary)',
+              color: 'var(--color-background)',
+              opacity: submitRating.isPending || !allScored ? 0.6 : 1,
+            }}
+          >
+            {submitRating.isPending ? t('rating.submitting') : t('rating.submit')}
+          </button>
+        </form>
       </main>
     </AppLayout>
+  );
+}
+
+// ── CriterionRow ──────────────────────────────────────────────────────────────
+
+function CriterionRow({
+  criterion,
+  value,
+  onChange,
+  photos,
+}: {
+  criterion: CriteriaKey;
+  value: number | undefined;
+  onChange: (v: number) => void;
+  photos: Photo[];
+}) {
+  const { t } = useTranslation();
+  const label = t(`criteria.${criterion}`);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium">{label}</span>
+        {value !== undefined && (
+          <span
+            className="text-xs"
+            style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}
+          >
+            {t(`rating.grade_${value}`)}
+          </span>
+        )}
+      </div>
+
+      {/* Zone photos inline */}
+      {photos.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {photos.map((p) => (
+            <img
+              key={p.id}
+              src={p.thumbnail_url ?? p.url}
+              alt=""
+              className="h-20 w-20 object-cover rounded"
+            />
+          ))}
+        </div>
+      )}
+
+      {/* 1–6 grade buttons */}
+      <div className="flex gap-1">
+        <span
+          className="text-xs self-center mr-1 w-14 text-right"
+          style={{ color: 'color-mix(in srgb, var(--color-text) 50%, transparent)' }}
+        >
+          {t('rating.grade_1_short')}
+        </span>
+        {GRADES.map((g) => (
+          <button
+            key={g}
+            type="button"
+            onClick={() => onChange(g)}
+            className="flex-1 h-10 rounded font-mono font-bold text-sm border"
+            style={{
+              borderColor:
+                value === g
+                  ? 'var(--color-primary)'
+                  : 'color-mix(in srgb, var(--color-text) 25%, transparent)',
+              backgroundColor:
+                value === g
+                  ? 'var(--color-primary)'
+                  : 'transparent',
+              color: value === g ? 'var(--color-background)' : 'var(--color-text)',
+            }}
+          >
+            {g}
+          </button>
+        ))}
+        <span
+          className="text-xs self-center ml-1 w-14"
+          style={{ color: 'color-mix(in srgb, var(--color-text) 50%, transparent)' }}
+        >
+          {t('rating.grade_6_short')}
+        </span>
+      </div>
+    </div>
   );
 }

--- a/frontend/src/pages/RaterLoginPage.tsx
+++ b/frontend/src/pages/RaterLoginPage.tsx
@@ -1,16 +1,46 @@
-import { useParams } from 'react-router-dom';
+import { useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { AppLayout } from '@/components/layout/AppLayout';
 import { TurnScoreLogo } from '@/components/ui/TurnScoreLogo';
+import { useRaterLogin } from '@/api/hooks/useAuth';
+import { useAuthStore } from '@/stores/authStore';
 
 export function RaterLoginPage() {
   const { slug } = useParams<{ slug?: string }>();
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const login = useAuthStore((s) => s.login);
+  const raterLogin = useRaterLogin();
+
+  const [nickname, setNickname] = useState('');
+  const [code, setCode] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!nickname.trim() || !code.trim() || !slug) return;
+    setError(null);
+    try {
+      const data = await raterLogin.mutateAsync({
+        tournament_slug: slug,
+        nickname: nickname.trim(),
+        code: code.trim(),
+      });
+      login(data.token, data.refresh_token ?? null);
+      navigate(`/t/${slug}`);
+    } catch {
+      setError(t('auth.error_invalid_credentials'));
+    }
+  };
 
   return (
     <AppLayout>
       <main className="flex min-h-[60vh] items-center justify-center">
-        <div className="w-full max-w-sm space-y-6 p-8 rounded" style={{ backgroundColor: 'var(--color-surface)' }}>
+        <div
+          className="w-full max-w-sm space-y-6 p-8 rounded"
+          style={{ backgroundColor: 'var(--color-surface)' }}
+        >
           <div className="flex justify-center">
             <TurnScoreLogo height={72} />
           </div>
@@ -18,11 +48,72 @@ export function RaterLoginPage() {
             {t('auth.rater_login_title')}
           </h1>
           {slug && (
-            <p className="text-sm text-center" style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}>
+            <p
+              className="text-sm text-center"
+              style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}
+            >
               {slug}
             </p>
           )}
-          <p className="text-sm text-center">{t('common.loading')}</p>
+
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                {t('auth.nickname_label')}
+              </label>
+              <input
+                type="text"
+                value={nickname}
+                onChange={(e) => setNickname(e.target.value)}
+                placeholder={t('auth.nickname_placeholder')}
+                autoComplete="nickname"
+                className="w-full px-3 py-2 rounded border text-sm"
+                style={{
+                  backgroundColor: 'var(--color-background)',
+                  borderColor: 'color-mix(in srgb, var(--color-primary) 30%, transparent)',
+                  color: 'var(--color-text)',
+                }}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                {t('auth.code_label')}
+              </label>
+              <input
+                type="text"
+                inputMode="numeric"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                placeholder={t('auth.code_placeholder')}
+                maxLength={6}
+                className="w-full px-3 py-2 rounded border text-sm font-mono"
+                style={{
+                  backgroundColor: 'var(--color-background)',
+                  borderColor: 'color-mix(in srgb, var(--color-primary) 30%, transparent)',
+                  color: 'var(--color-text)',
+                }}
+              />
+            </div>
+
+            {error && (
+              <p className="text-sm" style={{ color: '#dc2626' }}>
+                {error}
+              </p>
+            )}
+
+            <button
+              type="submit"
+              disabled={raterLogin.isPending || !nickname.trim() || !code.trim()}
+              className="w-full py-2 px-4 rounded font-medium text-sm"
+              style={{
+                backgroundColor: 'var(--color-primary)',
+                color: 'var(--color-background)',
+                opacity: raterLogin.isPending || !nickname.trim() || !code.trim() ? 0.6 : 1,
+              }}
+            >
+              {raterLogin.isPending ? t('common.loading') : t('auth.login_button')}
+            </button>
+          </form>
         </div>
       </main>
     </AppLayout>


### PR DESCRIPTION
## What was done?

Implements the full rater flow (Epic 3, US-20–US-26):

- **RaterLoginPage** (`/rate-login/:slug`): nickname + code form → `POST /auth/rater` → JWT stored → redirect to tournament overview
- **RatePage** (`/rate/:slug/:tableNum`): full rating form
  - Redirects unauthenticated users to rater login
  - Loads `TableDetail` (public endpoint — no org auth needed)
  - 1–6 school grade buttons per active criterion
  - Zone photos shown inline next to `zone_a` / `zone_b` criteria
  - Played zone selector (No / Zone A / Zone B)
  - Optional comment, max 1000 characters
  - Already-rated (409) → friendly message instead of error
- New hooks: `useRaterLogin`, `useGetTable`, `useSubmitRating`
- 401 interceptor: raters redirect to `/rate-login`, organizers to `/login`

## Why?

Closes #19

## Checklist
- [x] All US-20–US-26 user stories covered
- [x] No new dependencies
- [x] No secrets in code
- [x] CLAUDE.md rules followed (rater identity not exposed)