### PR TITLE
fix(frontend): rater login state in navbar with mobile avatar

### DIFF
--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -6,7 +6,7 @@ import { TurnScoreLogo } from '@/components/ui/TurnScoreLogo';
 
 export function Navbar() {
   const { t, i18n } = useTranslation();
-  const { isAuthenticated, logout, role } = useAuthStore();
+  const { isAuthenticated, logout, role, nickname } = useAuthStore();
   const navigate = useNavigate();
   const [menuOpen, setMenuOpen] = useState(false);
 
@@ -17,10 +17,17 @@ export function Navbar() {
   };
 
   const handleLogout = () => {
+    const wasRater = role === 'rater';
     logout();
-    navigate('/login');
+    navigate(wasRater ? '/rate-login' : '/login');
     setMenuOpen(false);
   };
+
+  const isRater = isAuthenticated() && role === 'rater';
+  const isUser = isAuthenticated() && role === 'user';
+
+  // Initial letter for the rater avatar
+  const raterInitial = nickname ? nickname.charAt(0).toUpperCase() : '?';
 
   const linkClass = 'flex items-center h-9 px-3 rounded text-sm font-medium hover:bg-[color-mix(in_srgb,var(--color-primary)_12%,transparent)] transition-colors';
   const logoutClass = 'flex items-center h-9 px-3 rounded text-sm font-medium border transition-colors hover:opacity-80';
@@ -47,13 +54,45 @@ export function Navbar() {
         <div className="hidden sm:flex items-center gap-1">
           <Link to="/" className={linkClass}>{t('nav.home')}</Link>
 
-          {isAuthenticated() && role === 'user' && (
+          {isUser && (
             <Link to="/dashboard" className={linkClass}>
               {t('nav.dashboard')}
             </Link>
           )}
 
-          {isAuthenticated() ? (
+          {/* Rater: nickname pill + logout */}
+          {isRater && (
+            <div className="flex items-center gap-2 ml-1">
+              <div
+                className="flex items-center gap-2 px-3 h-9 rounded text-sm font-medium"
+                style={{
+                  backgroundColor: 'color-mix(in srgb, var(--color-primary) 12%, transparent)',
+                  color: 'var(--color-primary)',
+                }}
+                title={t('auth.logged_in_as', { name: nickname })}
+              >
+                <span
+                  className="flex items-center justify-center w-5 h-5 rounded-full text-xs font-bold shrink-0"
+                  style={{ backgroundColor: 'var(--color-primary)', color: 'var(--color-background)' }}
+                  aria-hidden="true"
+                >
+                  {raterInitial}
+                </span>
+                <span className="max-w-[120px] truncate">{nickname}</span>
+              </div>
+              <button
+                onClick={handleLogout}
+                className={logoutClass}
+                style={{ borderColor: 'var(--color-accent)', color: 'var(--color-accent)' }}
+                aria-label={t('nav.logout')}
+              >
+                {t('nav.logout')}
+              </button>
+            </div>
+          )}
+
+          {/* Organizer: logout */}
+          {isUser && (
             <button
               onClick={handleLogout}
               className={logoutClass}
@@ -62,7 +101,9 @@ export function Navbar() {
             >
               {t('nav.logout')}
             </button>
-          ) : (
+          )}
+
+          {!isAuthenticated() && (
             <Link to="/login" className={linkClass}>{t('nav.login')}</Link>
           )}
 
@@ -86,27 +127,39 @@ export function Navbar() {
           </div>
         </div>
 
-        {/* Mobile hamburger button */}
-        <button
-          className="sm:hidden flex items-center justify-center h-9 w-9 rounded"
-          onClick={() => setMenuOpen((o) => !o)}
-          aria-expanded={menuOpen}
-          aria-label="Toggle menu"
-          style={{ color: 'var(--color-text)' }}
-        >
-          {menuOpen ? (
-            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-              <line x1="4" y1="4" x2="16" y2="16" />
-              <line x1="16" y1="4" x2="4" y2="16" />
-            </svg>
-          ) : (
-            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-              <line x1="3" y1="6" x2="17" y2="6" />
-              <line x1="3" y1="10" x2="17" y2="10" />
-              <line x1="3" y1="14" x2="17" y2="14" />
-            </svg>
+        {/* Mobile: rater avatar (always visible) + hamburger */}
+        <div className="sm:hidden flex items-center gap-2">
+          {isRater && (
+            <div
+              className="flex items-center justify-center w-8 h-8 rounded-full text-sm font-bold shrink-0"
+              style={{ backgroundColor: 'var(--color-primary)', color: 'var(--color-background)' }}
+              title={nickname ?? undefined}
+              aria-label={t('auth.logged_in_as', { name: nickname })}
+            >
+              {raterInitial}
+            </div>
           )}
-        </button>
+          <button
+            className="flex items-center justify-center h-9 w-9 rounded"
+            onClick={() => setMenuOpen((o) => !o)}
+            aria-expanded={menuOpen}
+            aria-label="Toggle menu"
+            style={{ color: 'var(--color-text)' }}
+          >
+            {menuOpen ? (
+              <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                <line x1="4" y1="4" x2="16" y2="16" />
+                <line x1="16" y1="4" x2="4" y2="16" />
+              </svg>
+            ) : (
+              <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                <line x1="3" y1="6" x2="17" y2="6" />
+                <line x1="3" y1="10" x2="17" y2="10" />
+                <line x1="3" y1="14" x2="17" y2="14" />
+              </svg>
+            )}
+          </button>
+        </div>
       </nav>
 
       {/* Mobile dropdown menu */}
@@ -119,13 +172,44 @@ export function Navbar() {
             {t('nav.home')}
           </Link>
 
-          {isAuthenticated() && role === 'user' && (
+          {isUser && (
             <Link to="/dashboard" className={mobileLinkClass} onClick={() => setMenuOpen(false)}>
               {t('nav.dashboard')}
             </Link>
           )}
 
-          {isAuthenticated() ? (
+          {/* Rater: identity row + logout */}
+          {isRater && (
+            <>
+              <div
+                className="flex items-center gap-3 h-11 px-4 rounded"
+                style={{ backgroundColor: 'color-mix(in srgb, var(--color-primary) 10%, transparent)' }}
+              >
+                <span
+                  className="flex items-center justify-center w-7 h-7 rounded-full text-sm font-bold shrink-0"
+                  style={{ backgroundColor: 'var(--color-primary)', color: 'var(--color-background)' }}
+                  aria-hidden="true"
+                >
+                  {raterInitial}
+                </span>
+                <span
+                  className="text-sm font-medium truncate"
+                  style={{ color: 'var(--color-primary)' }}
+                >
+                  {nickname}
+                </span>
+              </div>
+              <button
+                onClick={handleLogout}
+                className="flex items-center h-11 px-4 rounded text-sm font-medium border transition-colors hover:opacity-80"
+                style={{ borderColor: 'var(--color-accent)', color: 'var(--color-accent)' }}
+              >
+                {t('nav.logout')}
+              </button>
+            </>
+          )}
+
+          {isUser && (
             <button
               onClick={handleLogout}
               className="flex items-center h-11 px-4 rounded text-sm font-medium border transition-colors hover:opacity-80"
@@ -133,7 +217,9 @@ export function Navbar() {
             >
               {t('nav.logout')}
             </button>
-          ) : (
+          )}
+
+          {!isAuthenticated() && (
             <Link to="/login" className={mobileLinkClass} onClick={() => setMenuOpen(false)}>
               {t('nav.login')}
             </Link>

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -22,6 +22,7 @@
     "code_placeholder": "Dein Zugangscode",
     "login_button": "Bewertung starten",
     "logout_confirm": "Abmelden?",
+    "logged_in_as": "Eingeloggt als {{name}}",
     "error_invalid_credentials": "Ungültiger Spitzname oder Code.",
     "slug_label": "Turnier-Slug",
     "slug_placeholder": "z. B. essen-open-2025"

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -22,6 +22,7 @@
     "code_placeholder": "Your access code",
     "login_button": "Start Rating",
     "logout_confirm": "Sign out?",
+    "logged_in_as": "Logged in as {{name}}",
     "error_invalid_credentials": "Invalid nickname or code.",
     "slug_label": "Tournament Slug",
     "slug_placeholder": "e.g. essen-open-2025"

--- a/frontend/src/pages/RaterLoginPage.tsx
+++ b/frontend/src/pages/RaterLoginPage.tsx
@@ -30,7 +30,7 @@ export function RaterLoginPage() {
         nickname: nickname.trim(),
         code: code.trim(),
       });
-      login(data.token, data.refresh_token ?? null);
+      login(data.token, data.refresh_token ?? null, nickname.trim());
       navigate(`/t/${slug.trim()}`);
     } catch {
       setError(t('auth.error_invalid_credentials'));

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -23,7 +23,8 @@ interface AuthState {
   refreshToken: string | null;
   userId: string | null;
   role: Role | null;
-  login: (token: string, refreshToken: string | null) => void;
+  nickname: string | null;
+  login: (token: string, refreshToken: string | null, nickname?: string) => void;
   logout: () => void;
   isAuthenticated: () => boolean;
   hasRole: (...roles: string[]) => boolean;
@@ -36,14 +37,15 @@ export const useAuthStore = create<AuthState>()(
       refreshToken: null,
       userId: null,
       role: null,
-      login: (token, refreshToken) => {
+      nickname: null,
+      login: (token, refreshToken, nickname) => {
         const claims = parseJWT(token);
         if (claims) {
-          set({ token, refreshToken, userId: claims.sub, role: claims.role });
+          set({ token, refreshToken, userId: claims.sub, role: claims.role, nickname: nickname ?? null });
         }
       },
       logout: () =>
-        set({ token: null, refreshToken: null, userId: null, role: null }),
+        set({ token: null, refreshToken: null, userId: null, role: null, nickname: null }),
       isAuthenticated: () => {
         const { token } = get();
         if (!token) return false;


### PR DESCRIPTION
## What was done?
- `authStore`: added `nickname` field; `login()` accepts optional third param to store it (not in JWT)
- `RaterLoginPage`: passes the form's nickname to `login()` after successful auth
- **Navbar desktop**: logged-in rater sees a colored pill with initial + name before the logout button
- **Navbar mobile**: rater initial letter shown as avatar circle **always visible** next to the hamburger icon — no need to open the menu to know you're logged in. Menu shows full nickname row + logout button
- Rater logout redirects to `/rate-login` instead of `/login` (Google OAuth)
- i18n: added `auth.logged_in_as` (EN + DE)

## Why?
Participants had no visual indication they were authenticated. On mobile this is especially important since the whole session revolves around quickly rating tables via QR code.

Closes #69

## Checklist
- [x] No new dependencies
- [x] No secrets in code
- [x] CLAUDE.md rules followed (no nickname in JWT)