### PR TITLE
feat(frontend): photo gallery + lightbox with swipe (#96, #97)

### DIFF
--- a/frontend/src/pages/RatePage.tsx
+++ b/frontend/src/pages/RatePage.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
+import { X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { AppLayout } from '@/components/layout/AppLayout';
 import { useGetTable, useSubmitRating } from '@/api/hooks/useTables';
@@ -42,6 +43,7 @@ export function RatePage() {
   const [submitted, setSubmitted] = useState(false);
   const [alreadyRated, setAlreadyRated] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [galleryIndex, setGalleryIndex] = useState<number | null>(null);
 
   // Redirect unauthenticated raters to login
   if (!isAuthenticated() || !hasRole('rater')) {
@@ -87,10 +89,15 @@ export function RatePage() {
 
   const activeCriteria = table.active_criteria as CriteriaKey[];
   const tableCriteria = activeCriteria.filter((c) => !OPTIONAL_CRITERIA.includes(c));
+  const allPhotos = table.photos;
   const zonePhotos = {
-    zone_a: table.photos.filter((p) => p.category === 'zone_a'),
-    zone_b: table.photos.filter((p) => p.category === 'zone_b'),
-    general: table.photos.filter((p) => p.category === 'general'),
+    zone_a: allPhotos.filter((p) => p.category === 'zone_a'),
+    zone_b: allPhotos.filter((p) => p.category === 'zone_b'),
+    general: allPhotos.filter((p) => p.category === 'general'),
+  };
+  const openGallery = (photo: Photo) => {
+    const idx = allPhotos.findIndex((p) => p.id === photo.id);
+    setGalleryIndex(idx >= 0 ? idx : 0);
   };
 
   const allScored = tableCriteria.every((c) => scores[c] !== undefined);
@@ -165,12 +172,19 @@ export function RatePage() {
         {zonePhotos.general.length > 0 && (
           <div className="flex flex-wrap gap-2">
             {zonePhotos.general.map((p) => (
-              <img
+              <button
                 key={p.id}
-                src={p.url}
-                alt=""
-                className="h-28 w-28 object-cover rounded"
-              />
+                type="button"
+                onClick={() => openGallery(p)}
+                className="rounded overflow-hidden"
+                aria-label="View photo"
+              >
+                <img
+                  src={p.thumbnail_url ?? p.url}
+                  alt=""
+                  className="h-28 w-28 object-cover cursor-zoom-in"
+                />
+              </button>
             ))}
           </div>
         )}
@@ -190,6 +204,7 @@ export function RatePage() {
                     ? zonePhotos.zone_b
                     : []
                 }
+                onPhotoClick={(p) => openGallery(p)}
               />
             ))}
           </div>
@@ -269,7 +284,117 @@ export function RatePage() {
           </button>
         </form>
       </main>
+
+      {galleryIndex !== null && (
+        <GalleryLightbox photos={allPhotos} initialIndex={galleryIndex} onClose={() => setGalleryIndex(null)} />
+      )}
     </AppLayout>
+  );
+}
+
+// ── GalleryLightbox ───────────────────────────────────────────────────────────
+
+function GalleryLightbox({ photos, initialIndex, onClose }: {
+  photos: Photo[];
+  initialIndex: number;
+  onClose: () => void;
+}) {
+  const [index, setIndex] = useState(initialIndex);
+  const total = photos.length;
+  const prev = () => setIndex((i) => (i - 1 + total) % total);
+  const next = () => setIndex((i) => (i + 1) % total);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+      if (e.key === 'ArrowLeft') setIndex((i) => (i - 1 + total) % total);
+      if (e.key === 'ArrowRight') setIndex((i) => (i + 1) % total);
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onClose, total]);
+
+  // Touch swipe
+  const touchStartX = useRef<number | null>(null);
+  const handleTouchStart = (e: React.TouchEvent) => { touchStartX.current = e.touches[0].clientX; };
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    if (touchStartX.current === null) return;
+    const delta = e.changedTouches[0].clientX - touchStartX.current;
+    if (Math.abs(delta) > 50) { delta < 0 ? next() : prev(); }
+    touchStartX.current = null;
+  };
+
+  const current = photos[index];
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ backgroundColor: 'rgba(0,0,0,0.90)' }}
+      onClick={onClose}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+      role="dialog"
+      aria-modal="true"
+    >
+      {/* Close */}
+      <button
+        type="button"
+        className="absolute top-4 right-4 p-2 rounded-full"
+        style={{ backgroundColor: 'rgba(255,255,255,0.15)', color: 'white' }}
+        onClick={onClose}
+        aria-label="Close"
+      >
+        <X className="h-5 w-5" />
+      </button>
+
+      {/* Counter + category */}
+      <div
+        className="absolute top-4 left-4 flex items-center gap-2 text-sm text-white"
+        style={{ textShadow: '0 1px 3px rgba(0,0,0,0.8)' }}
+      >
+        <span>{index + 1} / {total}</span>
+        {current.category && current.category !== 'general' && (
+          <span
+            className="px-2 py-0.5 rounded text-xs font-bold"
+            style={{ backgroundColor: 'rgba(255,255,255,0.2)' }}
+          >
+            Zone {current.category === 'zone_a' ? 'A' : 'B'}
+          </span>
+        )}
+      </div>
+
+      {/* Image */}
+      <img
+        src={current.url}
+        alt=""
+        className="max-h-[85vh] max-w-[90vw] rounded object-contain"
+        onClick={(e) => e.stopPropagation()}
+      />
+
+      {/* Prev / Next */}
+      {total > 1 && (
+        <>
+          <button
+            type="button"
+            className="absolute left-3 top-1/2 -translate-y-1/2 p-3 rounded-full text-xl font-bold"
+            style={{ backgroundColor: 'rgba(255,255,255,0.15)', color: 'white' }}
+            onClick={(e) => { e.stopPropagation(); prev(); }}
+            aria-label="Previous photo"
+          >
+            ‹
+          </button>
+          <button
+            type="button"
+            className="absolute right-3 top-1/2 -translate-y-1/2 p-3 rounded-full text-xl font-bold"
+            style={{ backgroundColor: 'rgba(255,255,255,0.15)', color: 'white' }}
+            onClick={(e) => { e.stopPropagation(); next(); }}
+            aria-label="Next photo"
+          >
+            ›
+          </button>
+        </>
+      )}
+    </div>
   );
 }
 
@@ -280,11 +405,13 @@ function CriterionRow({
   value,
   onChange,
   photos,
+  onPhotoClick,
 }: {
   criterion: CriteriaKey;
   value: number | undefined;
   onChange: (v: number) => void;
   photos: Photo[];
+  onPhotoClick: (photo: Photo) => void;
 }) {
   const { t } = useTranslation();
   const label = t(`criteria.${criterion}`);
@@ -307,12 +434,19 @@ function CriterionRow({
       {photos.length > 0 && (
         <div className="flex flex-wrap gap-2">
           {photos.map((p) => (
-            <img
+            <button
               key={p.id}
-              src={p.thumbnail_url ?? p.url}
-              alt=""
-              className="h-20 w-20 object-cover rounded"
-            />
+              type="button"
+              onClick={() => onPhotoClick(p)}
+              className="rounded overflow-hidden"
+              aria-label="View photo"
+            >
+              <img
+                src={p.thumbnail_url ?? p.url}
+                alt=""
+                className="h-20 w-20 object-cover cursor-zoom-in"
+              />
+            </button>
           ))}
         </div>
       )}

--- a/frontend/src/pages/TournamentPage.tsx
+++ b/frontend/src/pages/TournamentPage.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
-import { Swords } from 'lucide-react';
+import { Swords, Camera, X } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import { useTranslation } from 'react-i18next';
 import { AppLayout } from '@/components/layout/AppLayout';
@@ -343,43 +343,231 @@ function TableCard({ slug, table, showRateButton, rateLabel, tableLabel }: {
   rateLabel: string;
   tableLabel: string;
 }) {
-  const firstPhoto = table.photos?.[0];
-  const thumbUrl = firstPhoto?.thumbnail_url ?? firstPhoto?.url;
+  const { t } = useTranslation();
+  const [galleryIndex, setGalleryIndex] = useState<number | null>(null);
+  const photos = table.photos ?? [];
+  const photoCount = photos.length;
+
+  const openGallery = (i: number) => setGalleryIndex(i);
+  const closeGallery = () => setGalleryIndex(null);
+
+  return (
+    <>
+      <div
+        className="rounded border overflow-hidden"
+        style={{
+          backgroundColor: 'var(--color-surface)',
+          borderColor: 'color-mix(in srgb, var(--color-primary) 20%, transparent)',
+        }}
+      >
+        {/* Photo gallery preview */}
+        {photoCount === 1 && (
+          <button type="button" className="w-full block" onClick={() => openGallery(0)}>
+            <img
+              src={photos[0].thumbnail_url ?? photos[0].url}
+              alt=""
+              className="w-full h-36 object-cover cursor-zoom-in"
+            />
+          </button>
+        )}
+        {photoCount > 1 && (
+          <div className="flex gap-1 p-1">
+            {/* Main photo */}
+            <button
+              type="button"
+              className="relative flex-1 overflow-hidden rounded"
+              style={{ height: 128 }}
+              onClick={() => openGallery(0)}
+            >
+              <img
+                src={photos[0].thumbnail_url ?? photos[0].url}
+                alt=""
+                className="w-full h-full object-cover cursor-zoom-in"
+              />
+              <CategoryBadge category={photos[0].category} />
+            </button>
+            {/* Thumbnail column — max 2 visible */}
+            <div className="flex flex-col gap-1">
+              {photos.slice(1, 3).map((p, i) => {
+                const isLast = i === 1;
+                const remaining = photoCount - 3;
+                return (
+                  <button
+                    key={p.id}
+                    type="button"
+                    className="relative overflow-hidden rounded"
+                    style={{ width: 60, height: 62 }}
+                    onClick={() => openGallery(i + 1)}
+                  >
+                    <img
+                      src={p.thumbnail_url ?? p.url}
+                      alt=""
+                      className="w-full h-full object-cover cursor-zoom-in"
+                    />
+                    <CategoryBadge category={p.category} />
+                    {isLast && remaining > 0 && (
+                      <div
+                        className="absolute inset-0 flex items-center justify-center text-sm font-bold text-white"
+                        style={{ backgroundColor: 'rgba(0,0,0,0.55)' }}
+                      >
+                        +{remaining}
+                      </div>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        <div className="p-3 flex items-center justify-between gap-2">
+          <div className="min-w-0">
+            <p className="font-medium text-sm truncate">{tableLabel}</p>
+            {table.name && (
+              <p className="text-xs truncate" style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}>
+                {table.name}
+              </p>
+            )}
+            {photoCount > 0 && (
+              <p className="flex items-center gap-1 text-xs mt-0.5" style={{ color: 'color-mix(in srgb, var(--color-text) 55%, transparent)' }}>
+                <Camera className="h-3 w-3" aria-hidden />
+                {photoCount} {t('table.photos')}
+              </p>
+            )}
+          </div>
+          {showRateButton && (
+            <Link
+              to={`/rate/${slug}/${table.number}`}
+              className="shrink-0 inline-flex items-center justify-center text-xs px-3 py-1.5 rounded font-medium"
+              style={{ backgroundColor: 'var(--color-primary)', color: 'var(--color-background)' }}
+            >
+              {rateLabel}
+            </Link>
+          )}
+        </div>
+      </div>
+
+      {galleryIndex !== null && (
+        <GalleryLightbox photos={photos} initialIndex={galleryIndex} onClose={closeGallery} />
+      )}
+    </>
+  );
+}
+
+function CategoryBadge({ category }: { category?: string | null }) {
+  if (!category || category === 'general') return null;
+  return (
+    <span
+      className="absolute bottom-1 right-1 text-xs font-bold px-1.5 py-0.5 rounded leading-none"
+      style={{ backgroundColor: 'rgba(0,0,0,0.6)', color: 'white' }}
+    >
+      {category === 'zone_a' ? 'A' : 'B'}
+    </span>
+  );
+}
+
+// ── GalleryLightbox ───────────────────────────────────────────────────────────
+
+function GalleryLightbox({ photos, initialIndex, onClose }: {
+  photos: TableSummary['photos'];
+  initialIndex: number;
+  onClose: () => void;
+}) {
+  const [index, setIndex] = useState(initialIndex);
+  const total = photos.length;
+  const prev = () => setIndex((i) => (i - 1 + total) % total);
+  const next = () => setIndex((i) => (i + 1) % total);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+      if (e.key === 'ArrowLeft') setIndex((i) => (i - 1 + total) % total);
+      if (e.key === 'ArrowRight') setIndex((i) => (i + 1) % total);
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onClose, total]);
+
+  // Touch swipe
+  const touchStartX = useRef<number | null>(null);
+  const handleTouchStart = (e: React.TouchEvent) => { touchStartX.current = e.touches[0].clientX; };
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    if (touchStartX.current === null) return;
+    const delta = e.changedTouches[0].clientX - touchStartX.current;
+    if (Math.abs(delta) > 50) { delta < 0 ? next() : prev(); }
+    touchStartX.current = null;
+  };
+
+  const current = photos[index];
 
   return (
     <div
-      className="rounded border overflow-hidden"
-      style={{
-        backgroundColor: 'var(--color-surface)',
-        borderColor: 'color-mix(in srgb, var(--color-primary) 20%, transparent)',
-      }}
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ backgroundColor: 'rgba(0,0,0,0.90)' }}
+      onClick={onClose}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+      role="dialog"
+      aria-modal="true"
     >
-      {thumbUrl && (
-        <img
-          src={thumbUrl}
-          alt=""
-          className="w-full h-32 object-cover"
-        />
-      )}
-      <div className="p-3 flex items-center justify-between gap-2">
-        <div className="min-w-0">
-          <p className="font-medium text-sm truncate">{tableLabel}</p>
-          {table.name && (
-            <p className="text-xs truncate" style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}>
-              {table.name}
-            </p>
-          )}
-        </div>
-        {showRateButton && (
-          <Link
-            to={`/rate/${slug}/${table.number}`}
-            className="shrink-0 inline-flex items-center justify-center text-xs px-3 py-1.5 rounded font-medium"
-            style={{ backgroundColor: 'var(--color-primary)', color: 'var(--color-background)' }}
+      {/* Close */}
+      <button
+        type="button"
+        className="absolute top-4 right-4 p-2 rounded-full"
+        style={{ backgroundColor: 'rgba(255,255,255,0.15)', color: 'white' }}
+        onClick={onClose}
+        aria-label="Close"
+      >
+        <X className="h-5 w-5" />
+      </button>
+
+      {/* Counter + category */}
+      <div
+        className="absolute top-4 left-4 flex items-center gap-2 text-sm text-white"
+        style={{ textShadow: '0 1px 3px rgba(0,0,0,0.8)' }}
+      >
+        <span>{index + 1} / {total}</span>
+        {current.category && current.category !== 'general' && (
+          <span
+            className="px-2 py-0.5 rounded text-xs font-bold"
+            style={{ backgroundColor: 'rgba(255,255,255,0.2)' }}
           >
-            {rateLabel}
-          </Link>
+            Zone {current.category === 'zone_a' ? 'A' : 'B'}
+          </span>
         )}
       </div>
+
+      {/* Image */}
+      <img
+        src={current.url}
+        alt=""
+        className="max-h-[85vh] max-w-[90vw] rounded object-contain"
+        onClick={(e) => e.stopPropagation()}
+      />
+
+      {/* Prev / Next */}
+      {total > 1 && (
+        <>
+          <button
+            type="button"
+            className="absolute left-3 top-1/2 -translate-y-1/2 p-3 rounded-full"
+            style={{ backgroundColor: 'rgba(255,255,255,0.15)', color: 'white' }}
+            onClick={(e) => { e.stopPropagation(); prev(); }}
+            aria-label="Previous photo"
+          >
+            ‹
+          </button>
+          <button
+            type="button"
+            className="absolute right-3 top-1/2 -translate-y-1/2 p-3 rounded-full"
+            style={{ backgroundColor: 'rgba(255,255,255,0.15)', color: 'white' }}
+            onClick={(e) => { e.stopPropagation(); next(); }}
+            aria-label="Next photo"
+          >
+            ›
+          </button>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What was done?
- **TournamentPage**: table cards show all photos (even without login) in a gallery preview — 1 photo: full width; 2+: main photo + thumbnail column with +N overflow badge; Zone A/B category badge overlaid on zone photos; camera icon + photo count in card footer
- **RatePage**: all photos (general + zone) are clickable and open the gallery lightbox; zone photos remain inline next to their respective rating criteria
- **Gallery lightbox**: arrow button navigation, keyboard ← → and Esc, touch swipe on mobile (50px threshold), photo counter (x / total), Zone A/B label for zone photos

## Why?
Closes #96 — photo count per table was missing  
Closes #97 — no lightbox and zone photos not clearly connected to criteria

## Checklist
- [x] Tests written and passing
- [x] `make licenses` run (no new dependencies added)
- [x] No secrets in code
- [x] CLAUDE.md rules followed

🤖 Generated with [Claude Code](https://claude.com/claude-code)