### PR TITLE
feat: rater progress indicator + voting CTA for guests (#83, #98)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1492,6 +1492,36 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
 
+  /tournaments/{slug}/my-ratings:
+    parameters:
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+
+    get:
+      summary: Get table numbers already rated by the current rater
+      operationId: getMyRatings
+      tags: [Ratings]
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: List of rated table numbers
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [rated_table_numbers]
+                properties:
+                  rated_table_numbers:
+                    type: array
+                    items:
+                      type: integer
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
   # =========================================================================
   # Results
   # =========================================================================

--- a/backend/internal/api/generated/api.gen.go
+++ b/backend/internal/api/generated/api.gen.go
@@ -641,6 +641,9 @@ type ServerInterface interface {
 	// Remove helper from tournament (organizer only)
 	// (DELETE /tournaments/{slug}/members/{userId})
 	RemoveTournamentMember(c *gin.Context, slug string, userId UUID)
+	// Get table numbers already rated by the current rater
+	// (GET /tournaments/{slug}/my-ratings)
+	GetMyRatings(c *gin.Context, slug string)
 	// Export all QR codes as print-ready PDF (organizer or helper)
 	// (POST /tournaments/{slug}/qrcodes)
 	ExportQRCodesPDF(c *gin.Context, slug string)
@@ -1106,6 +1109,32 @@ func (siw *ServerInterfaceWrapper) RemoveTournamentMember(c *gin.Context) {
 	siw.Handler.RemoveTournamentMember(c, slug, userId)
 }
 
+// GetMyRatings operation middleware
+func (siw *ServerInterfaceWrapper) GetMyRatings(c *gin.Context) {
+
+	var err error
+
+	// ------------- Path parameter "slug" -------------
+	var slug string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "slug", c.Param("slug"), &slug, runtime.BindStyledParameterOptions{Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter slug: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	c.Set(BearerAuthScopes, []string{})
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.GetMyRatings(c, slug)
+}
+
 // ExportQRCodesPDF operation middleware
 func (siw *ServerInterfaceWrapper) ExportQRCodesPDF(c *gin.Context) {
 
@@ -1567,6 +1596,7 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.POST(options.BaseURL+"/tournaments/:slug/members", wrapper.AddTournamentMember)
 	router.DELETE(options.BaseURL+"/tournaments/:slug/members/me", wrapper.LeaveTournament)
 	router.DELETE(options.BaseURL+"/tournaments/:slug/members/:userId", wrapper.RemoveTournamentMember)
+	router.GET(options.BaseURL+"/tournaments/:slug/my-ratings", wrapper.GetMyRatings)
 	router.POST(options.BaseURL+"/tournaments/:slug/qrcodes", wrapper.ExportQRCodesPDF)
 	router.GET(options.BaseURL+"/tournaments/:slug/raters", wrapper.ListRaters)
 	router.POST(options.BaseURL+"/tournaments/:slug/raters", wrapper.CreateRater)
@@ -2257,6 +2287,34 @@ type RemoveTournamentMember404JSONResponse struct{ NotFoundJSONResponse }
 func (response RemoveTournamentMember404JSONResponse) VisitRemoveTournamentMemberResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetMyRatingsRequestObject struct {
+	Slug string `json:"slug"`
+}
+
+type GetMyRatingsResponseObject interface {
+	VisitGetMyRatingsResponse(w http.ResponseWriter) error
+}
+
+type GetMyRatings200JSONResponse struct {
+	RatedTableNumbers []int `json:"rated_table_numbers"`
+}
+
+func (response GetMyRatings200JSONResponse) VisitGetMyRatingsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetMyRatings401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response GetMyRatings401JSONResponse) VisitGetMyRatingsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -3022,6 +3080,9 @@ type StrictServerInterface interface {
 	// Remove helper from tournament (organizer only)
 	// (DELETE /tournaments/{slug}/members/{userId})
 	RemoveTournamentMember(ctx context.Context, request RemoveTournamentMemberRequestObject) (RemoveTournamentMemberResponseObject, error)
+	// Get table numbers already rated by the current rater
+	// (GET /tournaments/{slug}/my-ratings)
+	GetMyRatings(ctx context.Context, request GetMyRatingsRequestObject) (GetMyRatingsResponseObject, error)
 	// Export all QR codes as print-ready PDF (organizer or helper)
 	// (POST /tournaments/{slug}/qrcodes)
 	ExportQRCodesPDF(ctx context.Context, request ExportQRCodesPDFRequestObject) (ExportQRCodesPDFResponseObject, error)
@@ -3600,6 +3661,33 @@ func (sh *strictHandler) RemoveTournamentMember(ctx *gin.Context, slug string, u
 		ctx.Status(http.StatusInternalServerError)
 	} else if validResponse, ok := response.(RemoveTournamentMemberResponseObject); ok {
 		if err := validResponse.VisitRemoveTournamentMemberResponse(ctx.Writer); err != nil {
+			ctx.Error(err)
+		}
+	} else if response != nil {
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetMyRatings operation middleware
+func (sh *strictHandler) GetMyRatings(ctx *gin.Context, slug string) {
+	var request GetMyRatingsRequestObject
+
+	request.Slug = slug
+
+	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.GetMyRatings(ctx, request.(GetMyRatingsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetMyRatings")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		ctx.Error(err)
+		ctx.Status(http.StatusInternalServerError)
+	} else if validResponse, ok := response.(GetMyRatingsResponseObject); ok {
+		if err := validResponse.VisitGetMyRatingsResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
 		}
 	} else if response != nil {

--- a/backend/internal/api/handlers/rater.go
+++ b/backend/internal/api/handlers/rater.go
@@ -244,6 +244,33 @@ func (h *Handlers) GetEventRatingStatus(ctx context.Context, req generated.GetEv
 	return generated.GetEventRatingStatus200JSONResponse{Submitted: submitted}, nil
 }
 
+// GetMyRatings returns the table numbers already rated by the current rater in this tournament.
+func (h *Handlers) GetMyRatings(ctx context.Context, req generated.GetMyRatingsRequestObject) (generated.GetMyRatingsResponseObject, error) {
+	raterID, ok := getUserID(ctx)
+	if !ok {
+		return generated.GetMyRatings401JSONResponse{
+			UnauthorizedJSONResponse: generated.UnauthorizedJSONResponse{Code: "unauthorized", Message: msgMissingRaterID},
+		}, nil
+	}
+	tournamentID, ok := getTournamentID(ctx)
+	if !ok {
+		return generated.GetMyRatings401JSONResponse{
+			UnauthorizedJSONResponse: generated.UnauthorizedJSONResponse{Code: "unauthorized", Message: msgMissingTournamentID},
+		}, nil
+	}
+
+	numbers, err := h.raterSvc.GetRatedTableNumbers(ctx, raterID, tournamentID, req.Slug)
+	if err != nil {
+		if errors.Is(err, domain.ErrForbidden) {
+			return generated.GetMyRatings401JSONResponse{
+				UnauthorizedJSONResponse: generated.UnauthorizedJSONResponse{Code: "unauthorized", Message: msgMissingTournamentID},
+			}, nil
+		}
+		return nil, err
+	}
+	return generated.GetMyRatings200JSONResponse{RatedTableNumbers: numbers}, nil
+}
+
 // GetTournamentResults returns tournament results (organizer or helper only).
 func (h *Handlers) GetTournamentResults(ctx context.Context, req generated.GetTournamentResultsRequestObject) (generated.GetTournamentResultsResponseObject, error) {
 	userID, ok := getUserID(ctx)

--- a/backend/internal/domain/rater.go
+++ b/backend/internal/domain/rater.go
@@ -97,4 +97,7 @@ type RatingRepository interface {
 	// GetCommentsForTournament returns all non-empty comments per table for a tournament.
 	// Returns map[tableID][]string of comments — fully anonymized, no rater identity.
 	GetCommentsForTournament(ctx context.Context, tournamentID uuid.UUID) (map[uuid.UUID][]string, error)
+
+	// GetRatedTableNumbers returns the table numbers (within a tournament) already rated by the given rater.
+	GetRatedTableNumbers(ctx context.Context, tournamentID, raterID uuid.UUID) ([]int, error)
 }

--- a/backend/internal/repository/rating.go
+++ b/backend/internal/repository/rating.go
@@ -49,6 +49,22 @@ func (r *RatingRepository) ExistsByTableAndRater(ctx context.Context, tableID, r
 	return count > 0, nil
 }
 
+// GetRatedTableNumbers returns the table numbers (within a tournament) that the given rater has already rated.
+func (r *RatingRepository) GetRatedTableNumbers(ctx context.Context, tournamentID, raterID uuid.UUID) ([]int, error) {
+	var numbers []int
+	err := r.db.WithContext(ctx).Raw(`
+		SELECT t.number
+		FROM ratings rt
+		JOIN tables t ON rt.table_id = t.id
+		WHERE t.tournament_id = ? AND rt.rater_id = ?
+		ORDER BY t.number ASC
+	`, tournamentID, raterID).Scan(&numbers).Error
+	if err != nil {
+		return nil, fmt.Errorf("GetRatedTableNumbers: %w", err)
+	}
+	return numbers, nil
+}
+
 // tableRow holds the raw SQL result from the aggregation query.
 type tableRow struct {
 	TableID     uuid.UUID `gorm:"column:table_id"`

--- a/backend/internal/service/rater.go
+++ b/backend/internal/service/rater.go
@@ -338,6 +338,18 @@ func (s *RaterService) HasEventRating(ctx context.Context, raterID, tournamentID
 	return s.eventRatingRepo.ExistsByTournamentAndRater(ctx, t.ID, raterID)
 }
 
+// GetRatedTableNumbers returns the table numbers within a tournament that the rater has already rated.
+func (s *RaterService) GetRatedTableNumbers(ctx context.Context, raterID, tournamentID uuid.UUID, slug string) ([]int, error) {
+	t, err := s.tourneyRepo.FindBySlug(ctx, slug)
+	if err != nil {
+		return nil, fmt.Errorf("GetRatedTableNumbers find tournament: %w", err)
+	}
+	if t.ID != tournamentID {
+		return nil, domain.ErrForbidden
+	}
+	return s.ratingRepo.GetRatedTableNumbers(ctx, t.ID, raterID)
+}
+
 // isVotingOpen returns true when rating submissions should be accepted.
 // Tournament must be "active" and the current time must be within the voting window
 // (if start/end are set).

--- a/backend/pkg/mocks/mock_rating_repo.go
+++ b/backend/pkg/mocks/mock_rating_repo.go
@@ -86,6 +86,21 @@ func (mr *MockRatingRepositoryMockRecorder) GetCommentsForTournament(ctx, tourna
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCommentsForTournament", reflect.TypeOf((*MockRatingRepository)(nil).GetCommentsForTournament), ctx, tournamentID)
 }
 
+// GetRatedTableNumbers mocks base method.
+func (m *MockRatingRepository) GetRatedTableNumbers(ctx context.Context, tournamentID, raterID uuid.UUID) ([]int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRatedTableNumbers", ctx, tournamentID, raterID)
+	ret0, _ := ret[0].([]int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRatedTableNumbers indicates an expected call of GetRatedTableNumbers.
+func (mr *MockRatingRepositoryMockRecorder) GetRatedTableNumbers(ctx, tournamentID, raterID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRatedTableNumbers", reflect.TypeOf((*MockRatingRepository)(nil).GetRatedTableNumbers), ctx, tournamentID, raterID)
+}
+
 // GetResultsForTournament mocks base method.
 func (m *MockRatingRepository) GetResultsForTournament(ctx context.Context, tournamentID uuid.UUID) ([]domain.RatingResult, error) {
 	m.ctrl.T.Helper()

--- a/frontend/src/api/generated/api.ts
+++ b/frontend/src/api/generated/api.ts
@@ -396,6 +396,25 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/tournaments/{slug}/my-ratings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                slug: string;
+            };
+            cookie?: never;
+        };
+        /** Get table numbers already rated by the current rater */
+        get: operations["getMyRatings"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/tournaments/{slug}/results": {
         parameters: {
             query?: never;
@@ -1590,6 +1609,31 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
+        };
+    };
+    getMyRatings: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of rated table numbers */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        rated_table_numbers: number[];
+                    };
+                };
+            };
+            401: components["responses"]["Unauthorized"];
         };
     };
     getTournamentResults: {

--- a/frontend/src/api/hooks/useEventRating.ts
+++ b/frontend/src/api/hooks/useEventRating.ts
@@ -13,6 +13,15 @@ export function useEventRatingStatus(slug: string, enabled: boolean) {
   });
 }
 
+export function useMyRatings(slug: string, enabled: boolean) {
+  return useQuery<{ rated_table_numbers: number[] }>({
+    queryKey: ['my-ratings', slug],
+    queryFn: () =>
+      apiClient.get(`/tournaments/${slug}/my-ratings`).then((r) => r.data),
+    enabled: enabled && !!slug,
+  });
+}
+
 export function useSubmitEventRating(slug: string) {
   const queryClient = useQueryClient();
   return useMutation<void, Error, CreateEventRatingRequest>({

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -46,7 +46,11 @@
     "location": "Ort",
     "links_disclaimer": "Wir übernehmen keine Verantwortung für externe Inhalte.",
     "no_tables": "Es wurden noch keine Tische angelegt.",
-    "rate_table": "Bewerten"
+    "rate_table": "Bewerten",
+    "table_rated": "Bewertet",
+    "voting_open_cta_title": "Abstimmung läuft!",
+    "voting_open_cta_text": "Melde dich als Teilnehmer an, um die Tische zu bewerten.",
+    "voting_open_cta_button": "Jetzt bewerten"
   },
   "table": {
     "number": "Tisch {{number}}",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -46,7 +46,11 @@
     "location": "Location",
     "links_disclaimer": "We are not responsible for the content of external links.",
     "no_tables": "No tables have been set up yet.",
-    "rate_table": "Rate"
+    "rate_table": "Rate",
+    "table_rated": "Rated",
+    "voting_open_cta_title": "Rating is open!",
+    "voting_open_cta_text": "Log in as a participant to rate the tables.",
+    "voting_open_cta_button": "Rate now"
   },
   "table": {
     "number": "Table {{number}}",

--- a/frontend/src/pages/RatePage.tsx
+++ b/frontend/src/pages/RatePage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { X } from 'lucide-react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { AppLayout } from '@/components/layout/AppLayout';
 import { useGetTable, useSubmitRating } from '@/api/hooks/useTables';
@@ -26,6 +27,7 @@ export function RatePage() {
   const { data: table, isLoading } = useGetTable(slug, tableNum);
   const submitRating = useSubmitRating(slug, tableNum);
   const { applyTheme, clearTheme } = useTheme();
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     if (!table?.tournament_type) return;
@@ -112,6 +114,7 @@ export function RatePage() {
         played_zone: playedZone,
         comment: comment.trim() || null,
       });
+      queryClient.invalidateQueries({ queryKey: ['my-ratings', slug] });
       setSubmitted(true);
     } catch (err: unknown) {
       const status = (err as { response?: { status?: number } })?.response?.status;
@@ -490,3 +493,4 @@ function CriterionRow({
     </div>
   );
 }
+

--- a/frontend/src/pages/TournamentPage.tsx
+++ b/frontend/src/pages/TournamentPage.tsx
@@ -7,7 +7,7 @@ import { AppLayout } from '@/components/layout/AppLayout';
 import { useTournament } from '@/api/hooks/useTournaments';
 import { useTheme } from '@/hooks/useTheme';
 import { useAuthStore } from '@/stores/authStore';
-import { useEventRatingStatus, useSubmitEventRating } from '@/api/hooks/useEventRating';
+import { useEventRatingStatus, useSubmitEventRating, useMyRatings } from '@/api/hooks/useEventRating';
 import type { TableSummary } from '@/api/hooks/useTables';
 import type { components } from '@/api/generated/api';
 
@@ -23,6 +23,9 @@ export function TournamentPage() {
   const { applyTheme, clearTheme } = useTheme();
   const { isAuthenticated, role } = useAuthStore();
   const isRater = isAuthenticated() && role === 'rater';
+  const isGuest = !isAuthenticated() || role !== 'rater';
+  const { data: myRatingsData } = useMyRatings(slug, isRater);
+  const ratedTables = myRatingsData?.rated_table_numbers ?? [];
 
   const isVotingActive = (() => {
     if (!tournament || tournament.status !== 'active') return false;
@@ -179,6 +182,33 @@ export function TournamentPage() {
               </div>
             )}
 
+            {/* CTA for guests when voting is active */}
+            {isVotingActive && isGuest && (
+              <div
+                className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 p-4 rounded border"
+                style={{
+                  backgroundColor: 'color-mix(in srgb, var(--color-primary) 8%, transparent)',
+                  borderColor: 'color-mix(in srgb, var(--color-primary) 30%, transparent)',
+                }}
+              >
+                <div>
+                  <p className="font-medium text-sm" style={{ color: 'var(--color-primary)' }}>
+                    {t('tournament.voting_open_cta_title')}
+                  </p>
+                  <p className="text-xs mt-0.5" style={{ color: 'color-mix(in srgb, var(--color-text) 65%, transparent)' }}>
+                    {t('tournament.voting_open_cta_text')}
+                  </p>
+                </div>
+                <Link
+                  to={`/rate-login/${slug}`}
+                  className="shrink-0 inline-flex items-center justify-center px-4 py-2 rounded font-medium text-sm"
+                  style={{ backgroundColor: 'var(--color-primary)', color: 'var(--color-background)' }}
+                >
+                  {t('tournament.voting_open_cta_button')}
+                </Link>
+              </div>
+            )}
+
             {/* Event Rating — shown above tables when optional criteria exist, rater is logged in, and voting is open */}
             {isRater && isVotingActive && tournament.active_criteria?.some((c) => OPTIONAL_CRITERIA.includes(c as CriteriaKey)) && (
               <EventRatingSection slug={slug} activeCriteria={(tournament.active_criteria as CriteriaKey[]).filter((c) => OPTIONAL_CRITERIA.includes(c))} />
@@ -197,7 +227,16 @@ export function TournamentPage() {
               ) : (
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                   {tournament.tables.map((table) => (
-                    <TableCard key={table.id} slug={slug} table={table} showRateButton={isRater && isVotingActive} rateLabel={t('tournament.rate_table')} tableLabel={t('table.number', { number: table.number })} />
+                    <TableCard
+                      key={table.id}
+                      slug={slug}
+                      table={table}
+                      showRateButton={isRater && isVotingActive}
+                      isRated={ratedTables.includes(table.number)}
+                      rateLabel={t('tournament.rate_table')}
+                      ratedLabel={t('tournament.table_rated')}
+                      tableLabel={t('table.number', { number: table.number })}
+                    />
                   ))}
                 </div>
               )}
@@ -336,11 +375,13 @@ function EventRatingSection({ slug, activeCriteria }: { slug: string; activeCrit
   );
 }
 
-function TableCard({ slug, table, showRateButton, rateLabel, tableLabel }: {
+function TableCard({ slug, table, showRateButton, isRated, rateLabel, ratedLabel, tableLabel }: {
   slug: string;
   table: TableSummary;
   showRateButton: boolean;
+  isRated: boolean;
   rateLabel: string;
+  ratedLabel: string;
   tableLabel: string;
 }) {
   const { t } = useTranslation();
@@ -435,7 +476,7 @@ function TableCard({ slug, table, showRateButton, rateLabel, tableLabel }: {
               </p>
             )}
           </div>
-          {showRateButton && (
+          {showRateButton && !isRated && (
             <Link
               to={`/rate/${slug}/${table.number}`}
               className="shrink-0 inline-flex items-center justify-center text-xs px-3 py-1.5 rounded font-medium"
@@ -443,6 +484,17 @@ function TableCard({ slug, table, showRateButton, rateLabel, tableLabel }: {
             >
               {rateLabel}
             </Link>
+          )}
+          {showRateButton && isRated && (
+            <span
+              className="shrink-0 inline-flex items-center gap-1 text-xs px-3 py-1.5 rounded font-medium"
+              style={{
+                backgroundColor: 'color-mix(in srgb, var(--color-primary) 15%, transparent)',
+                color: 'var(--color-primary)',
+              }}
+            >
+              ✓ {ratedLabel}
+            </span>
           )}
         </div>
       </div>


### PR DESCRIPTION
## What was done?
- **#83 — Rater progress**: After rating a table, a ✓ badge replaces the Rate button. Progress is stored server-side via `GET /tournaments/{slug}/my-ratings` — works cross-device and cross-session.
- **#98 — Voting CTA**: When voting is active and the user is not a rater, a prominent banner appears with a link to the rater login page (slug pre-filled).

## Technical details
- New OpenAPI endpoint `GET /tournaments/{slug}/my-ratings` — rater auth, returns `{ rated_table_numbers: [int] }`
- Backend: `RatingRepository.GetRatedTableNumbers`, `RaterService.GetRatedTableNumbers`, `Handlers.GetMyRatings`
- Frontend: `useMyRatings` hook; cache invalidated after successful submit
- Mock updated: `MockRatingRepository.GetRatedTableNumbers` added

Closes #83
Closes #98

## Checklist
- [x] Tests passing (`make test-be`)
- [x] `make licenses` run (no new dependencies added)
- [x] No secrets in code
- [x] CLAUDE.md rules followed

🤖 Generated with [Claude Code](https://claude.com/claude-code)