### PR TITLE
fix(frontend): show tables/raters/results buttons for helpers (#103)

### DIFF
--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -8,7 +8,6 @@ import type { TournamentMembership } from '@/api/hooks/useUser';
 
 export function DashboardPage() {
   const { t } = useTranslation();
-  const navigate = useNavigate();
   const { data: profile, isLoading } = useMe();
   const deleteTournament = useDeleteTournament();
   const [copiedCode, setCopiedCode] = useState(false);
@@ -106,31 +105,11 @@ export function DashboardPage() {
               >
                 <span className="font-medium text-sm">{m.tournament_name}</span>
                 <div className="flex gap-2 flex-wrap">
-                  <button
-                    onClick={() => navigate(`/dashboard/tournaments/${m.tournament_slug}`)}
-                    className="text-xs px-3 py-1 rounded border"
-                    style={{ borderColor: 'var(--color-primary)', color: 'var(--color-primary)' }}
-                  >
-                    {t('dashboard.manage')}
-                  </button>
-                  <Link
-                    to={`/dashboard/tournaments/${m.tournament_slug}/tables`}
-                    className="text-xs px-3 py-1 rounded border"
-                    style={{ borderColor: 'var(--color-primary)', color: 'var(--color-primary)' }}
-                  >
-                    {t('dashboard.tables')}
-                  </Link>
-                  <Link
-                    to={`/dashboard/tournaments/${m.tournament_slug}/results`}
-                    className="text-xs px-3 py-1 rounded border"
-                    style={{ borderColor: 'var(--color-accent)', color: 'var(--color-accent)' }}
-                  >
-                    {t('results.title')}
-                  </Link>
+                  <TournamentActionLinks slug={m.tournament_slug} />
                   <button
                     onClick={() => handleDelete(m)}
                     disabled={deleteTournament.isPending}
-                    className="text-xs px-3 py-1 rounded border"
+                    className="inline-flex items-center justify-center text-xs px-3 py-1 rounded border"
                     style={{ borderColor: '#dc2626', color: '#dc2626' }}
                     aria-label={`${t('dashboard.delete_tournament')} ${m.tournament_name}`}
                   >
@@ -168,7 +147,6 @@ export function DashboardPage() {
 
 function HelperRow({ membership: m }: { membership: TournamentMembership }) {
   const { t } = useTranslation();
-  const navigate = useNavigate();
   const leave = useLeaveTournament(m.tournament_slug);
 
   const handleLeave = async () => {
@@ -182,18 +160,12 @@ function HelperRow({ membership: m }: { membership: TournamentMembership }) {
       style={{ backgroundColor: 'var(--color-surface)' }}
     >
       <span className="font-medium text-sm">{m.tournament_name}</span>
-      <div className="flex gap-2">
-        <button
-          onClick={() => navigate(`/dashboard/tournaments/${m.tournament_slug}`)}
-          className="text-xs px-3 py-1 rounded border"
-          style={{ borderColor: 'var(--color-primary)', color: 'var(--color-primary)' }}
-        >
-          {t('dashboard.manage')}
-        </button>
+      <div className="flex gap-2 flex-wrap">
+        <TournamentActionLinks slug={m.tournament_slug} />
         <button
           onClick={handleLeave}
           disabled={leave.isPending}
-          className="text-xs px-3 py-1 rounded border"
+          className="inline-flex items-center justify-center text-xs px-3 py-1 rounded border"
           style={{ borderColor: '#dc2626', color: '#dc2626' }}
           aria-label={`${t('dashboard.leave_tournament')} ${m.tournament_name}`}
         >
@@ -201,5 +173,41 @@ function HelperRow({ membership: m }: { membership: TournamentMembership }) {
         </button>
       </div>
     </li>
+  );
+}
+
+function TournamentActionLinks({ slug }: { slug: string }) {
+  const { t } = useTranslation();
+  return (
+    <>
+      <Link
+        to={`/dashboard/tournaments/${slug}`}
+        className="inline-flex items-center justify-center text-xs px-3 py-1 rounded border"
+        style={{ borderColor: 'var(--color-primary)', color: 'var(--color-primary)' }}
+      >
+        {t('dashboard.manage')}
+      </Link>
+      <Link
+        to={`/dashboard/tournaments/${slug}/tables`}
+        className="inline-flex items-center justify-center text-xs px-3 py-1 rounded border"
+        style={{ borderColor: 'var(--color-primary)', color: 'var(--color-primary)' }}
+      >
+        {t('dashboard.tables')}
+      </Link>
+      <Link
+        to={`/dashboard/tournaments/${slug}/raters`}
+        className="inline-flex items-center justify-center text-xs px-3 py-1 rounded border"
+        style={{ borderColor: 'var(--color-primary)', color: 'var(--color-primary)' }}
+      >
+        {t('rater.section_title')}
+      </Link>
+      <Link
+        to={`/dashboard/tournaments/${slug}/results`}
+        className="inline-flex items-center justify-center text-xs px-3 py-1 rounded border"
+        style={{ borderColor: 'var(--color-accent)', color: 'var(--color-accent)' }}
+      >
+        {t('results.title')}
+      </Link>
+    </>
   );
 }

--- a/frontend/src/pages/dashboard/HelperTournamentsPage.tsx
+++ b/frontend/src/pages/dashboard/HelperTournamentsPage.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useMe } from '@/api/hooks/useUser';
 import { useLeaveTournament } from '@/api/hooks/useMembers';
@@ -37,7 +37,6 @@ export function HelperTournamentsPage() {
 
 function HelperRow({ membership: m }: { membership: TournamentMembership }) {
   const { t } = useTranslation();
-  const navigate = useNavigate();
   const leave = useLeaveTournament(m.tournament_slug);
 
   const handleLeave = async () => {
@@ -51,18 +50,39 @@ function HelperRow({ membership: m }: { membership: TournamentMembership }) {
       style={{ backgroundColor: 'var(--color-surface)' }}
     >
       <span className="font-medium">{m.tournament_name}</span>
-      <div className="flex gap-2">
-        <button
-          onClick={() => navigate(`/dashboard/tournaments/${m.tournament_slug}`)}
-          className="text-xs px-3 py-1 rounded border"
+      <div className="flex gap-2 flex-wrap">
+        <Link
+          to={`/dashboard/tournaments/${m.tournament_slug}`}
+          className="inline-flex items-center justify-center text-xs px-3 py-1 rounded border"
           style={{ borderColor: 'var(--color-primary)', color: 'var(--color-primary)' }}
         >
           {t('dashboard.manage')}
-        </button>
+        </Link>
+        <Link
+          to={`/dashboard/tournaments/${m.tournament_slug}/tables`}
+          className="inline-flex items-center justify-center text-xs px-3 py-1 rounded border"
+          style={{ borderColor: 'var(--color-primary)', color: 'var(--color-primary)' }}
+        >
+          {t('dashboard.tables')}
+        </Link>
+        <Link
+          to={`/dashboard/tournaments/${m.tournament_slug}/raters`}
+          className="inline-flex items-center justify-center text-xs px-3 py-1 rounded border"
+          style={{ borderColor: 'var(--color-primary)', color: 'var(--color-primary)' }}
+        >
+          {t('rater.section_title')}
+        </Link>
+        <Link
+          to={`/dashboard/tournaments/${m.tournament_slug}/results`}
+          className="inline-flex items-center justify-center text-xs px-3 py-1 rounded border"
+          style={{ borderColor: 'var(--color-accent)', color: 'var(--color-accent)' }}
+        >
+          {t('results.title')}
+        </Link>
         <button
           onClick={handleLeave}
           disabled={leave.isPending}
-          className="text-xs px-3 py-1 rounded border"
+          className="inline-flex items-center justify-center text-xs px-3 py-1 rounded border"
           style={{ borderColor: '#dc2626', color: '#dc2626' }}
           aria-label={`${t('dashboard.leave_tournament')} ${m.tournament_name}`}
         >


### PR DESCRIPTION
## What was done?
Helper tournament rows in `DashboardPage` and `HelperTournamentsPage` were missing Manage/Tables/Raters/Results action buttons — only "Manage" and "Leave" were shown.

Extracted a shared `TournamentActionLinks` component (Manage, Tables, Raters, Results) used by both organizer and helper rows. Delete button remains organizer-only.

Closes #103

## Checklist
- [x] No new dependencies
- [x] No secrets in code
- [x] CLAUDE.md rules followed

🤖 Generated with [Claude Code](https://claude.com/claude-code)