### PR TITLE
feat: results page — ranking, criteria, zones, comments (#20 #84)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -543,10 +543,18 @@ components:
 
     TournamentResults:
       type: object
-      required: [tournament_name, ranking]
+      required: [tournament_name, ranking, active_criteria, show_comments]
       properties:
         tournament_name:
           type: string
+        active_criteria:
+          type: array
+          description: Criteria keys active for this tournament (determines which columns to show)
+          items:
+            $ref: "#/components/schemas/CriteriaKey"
+        show_comments:
+          type: boolean
+          description: Whether comments are visible in results
         ranking:
           type: array
           description: Sorted ascending by overall average score (1 = best grade)

--- a/backend/internal/api/generated/api.gen.go
+++ b/backend/internal/api/generated/api.gen.go
@@ -435,9 +435,15 @@ type TournamentMembershipRole string
 
 // TournamentResults defines model for TournamentResults.
 type TournamentResults struct {
+	// ActiveCriteria Criteria keys active for this tournament (determines which columns to show)
+	ActiveCriteria []CriteriaKey `json:"active_criteria"`
+
 	// Ranking Sorted ascending by overall average score (1 = best grade)
-	Ranking        []TableResult `json:"ranking"`
-	TournamentName string        `json:"tournament_name"`
+	Ranking []TableResult `json:"ranking"`
+
+	// ShowComments Whether comments are visible in results
+	ShowComments   bool   `json:"show_comments"`
+	TournamentName string `json:"tournament_name"`
 }
 
 // TournamentStatus defines model for TournamentStatus.

--- a/backend/internal/api/handlers/rater.go
+++ b/backend/internal/api/handlers/rater.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 
 	"github.com/google/uuid"
@@ -297,8 +298,26 @@ func (h *Handlers) GetTournamentResults(ctx context.Context, req generated.GetTo
 
 	ranking := buildRanking(results, commentsMap)
 
+	// Parse active_criteria from tournament JSON field.
+	var activeCriteria []string
+	if err := json.Unmarshal([]byte(tournament.ActiveCriteria), &activeCriteria); err != nil {
+		activeCriteria = []string{}
+	}
+	apiCriteria := make([]generated.CriteriaKey, 0, len(activeCriteria))
+	for _, k := range activeCriteria {
+		apiCriteria = append(apiCriteria, generated.CriteriaKey(k))
+	}
+
+	// Parse show_comments from result config.
+	var resultCfg struct {
+		ShowComments bool `json:"show_comments"`
+	}
+	_ = json.Unmarshal([]byte(tournament.ResultConfig), &resultCfg)
+
 	return generated.GetTournamentResults200JSONResponse(generated.TournamentResults{
 		TournamentName: tournament.Name,
+		ActiveCriteria: apiCriteria,
+		ShowComments:   resultCfg.ShowComments,
 		Ranking:        ranking,
 	}), nil
 }

--- a/frontend/src/api/generated/api.ts
+++ b/frontend/src/api/generated/api.ts
@@ -705,6 +705,10 @@ export interface components {
         };
         TournamentResults: {
             tournament_name: string;
+            /** @description Criteria keys active for this tournament (determines which columns to show) */
+            active_criteria: components["schemas"]["CriteriaKey"][];
+            /** @description Whether comments are visible in results */
+            show_comments: boolean;
             /** @description Sorted ascending by overall average score (1 = best grade) */
             ranking: components["schemas"]["TableResult"][];
         };

--- a/frontend/src/api/hooks/useResults.ts
+++ b/frontend/src/api/hooks/useResults.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/api/client';
+import type { components } from '@/api/generated/api';
+
+export type TournamentResults = components['schemas']['TournamentResults'];
+export type TableResult = components['schemas']['TableResult'];
+
+export function useTournamentResults(slug: string) {
+  return useQuery<TournamentResults>({
+    queryKey: ['results', slug],
+    queryFn: () => apiClient.get(`/tournaments/${slug}/results`).then((r) => r.data),
+    enabled: !!slug,
+  });
+}

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -239,7 +239,16 @@
     "table": "Tisch",
     "average": "Durchschnitt",
     "ratings_count": "{{count}} Bewertungen",
-    "no_results": "Noch keine Bewertungen abgegeben."
+    "no_results": "Noch keine Bewertungen abgegeben.",
+    "criteria_breakdown": "Kriterienaufschlüsselung",
+    "zone_distribution": "Zonenverteilung",
+    "zone_none": "Nicht gespielt",
+    "zone_a": "Zone A",
+    "zone_b": "Zone B",
+    "comments": "Kommentare",
+    "overall_ranking": "Gesamtranking",
+    "show_criteria": "Kriterien anzeigen",
+    "hide_criteria": "Kriterien ausblenden"
   },
   "errors": {
     "generic": "Ein Fehler ist aufgetreten. Bitte versuche es erneut.",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -239,7 +239,16 @@
     "table": "Table",
     "average": "Average",
     "ratings_count": "{{count}} ratings",
-    "no_results": "No ratings submitted yet."
+    "no_results": "No ratings submitted yet.",
+    "criteria_breakdown": "Criteria breakdown",
+    "zone_distribution": "Zone distribution",
+    "zone_none": "Not played",
+    "zone_a": "Zone A",
+    "zone_b": "Zone B",
+    "comments": "Comments",
+    "overall_ranking": "Overall Ranking",
+    "show_criteria": "Show criteria",
+    "hide_criteria": "Hide criteria"
   },
   "errors": {
     "generic": "An error occurred. Please try again.",

--- a/frontend/src/pages/dashboard/ResultsPage.tsx
+++ b/frontend/src/pages/dashboard/ResultsPage.tsx
@@ -1,16 +1,221 @@
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+import { useTournamentResults, type TableResult } from '@/api/hooks/useResults';
 
 export function ResultsPage() {
   const { slug } = useParams<{ slug: string }>();
   const { t } = useTranslation();
+  const { data, isLoading, error } = useTournamentResults(slug ?? '');
+
+  if (isLoading) {
+    return <p className="text-sm" style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}>{t('common.loading')}</p>;
+  }
+
+  if (error || !data) {
+    return <p className="text-sm" style={{ color: '#dc2626' }}>{t('errors.generic')}</p>;
+  }
+
+  if (data.ranking.length === 0) {
+    return (
+      <div>
+        <h1 className="font-heading text-2xl font-bold mb-4">{t('results.title')}</h1>
+        <p className="text-sm" style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}>
+          {t('results.no_results')}
+        </p>
+      </div>
+    );
+  }
 
   return (
-    <div>
-      <h1 className="font-heading text-2xl font-bold mb-6">{t('results.title')}</h1>
-      <p className="text-sm" style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}>
-        {slug} — {t('results.no_results')}
+    <div className="space-y-6 max-w-4xl">
+      <h1 className="font-heading text-2xl font-bold">{t('results.title')}</h1>
+      <p className="text-sm font-medium" style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}>
+        {data.tournament_name}
       </p>
+
+      <div className="space-y-3">
+        {data.ranking.map((row, index) => (
+          <TableResultRow
+            key={row.table_number}
+            rank={index + 1}
+            result={row}
+            activeCriteria={data.active_criteria}
+            showComments={data.show_comments}
+          />
+        ))}
+      </div>
     </div>
+  );
+}
+
+interface TableResultRowProps {
+  rank: number;
+  result: TableResult;
+  activeCriteria: string[];
+  showComments: boolean;
+}
+
+function TableResultRow({ rank, result, activeCriteria, showComments }: TableResultRowProps) {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+
+  const overallAvg = result.average_scores['overall'];
+  const hasDetails =
+    activeCriteria.length > 1 ||
+    result.zone_distribution.zone_a > 0 ||
+    result.zone_distribution.zone_b > 0 ||
+    (showComments && result.comments && result.comments.length > 0);
+
+  return (
+    <div
+      className="rounded overflow-hidden"
+      style={{
+        backgroundColor: 'var(--color-surface)',
+        border: '1px solid color-mix(in srgb, var(--color-text) 15%, transparent)',
+      }}
+    >
+      {/* Main row */}
+      <div className="flex items-center gap-4 px-4 py-3">
+        {/* Rank badge */}
+        <span
+          className="font-heading text-lg font-bold w-8 text-center shrink-0"
+          style={{ color: rank <= 3 ? 'var(--color-primary)' : 'color-mix(in srgb, var(--color-text) 45%, transparent)' }}
+          aria-label={`${t('results.rank')} ${rank}`}
+        >
+          {rank}
+        </span>
+
+        {/* Table name/number */}
+        <div className="flex-1 min-w-0">
+          <span className="font-medium text-sm">
+            {result.table_name
+              ? `${t('results.table')} ${result.table_number} — ${result.table_name}`
+              : `${t('results.table')} ${result.table_number}`}
+          </span>
+          <p className="text-xs mt-0.5" style={{ color: 'color-mix(in srgb, var(--color-text) 50%, transparent)' }}>
+            {t('results.ratings_count', { count: result.rating_count })}
+          </p>
+        </div>
+
+        {/* Overall average */}
+        <div className="text-right shrink-0">
+          <span className="font-heading text-xl font-bold" style={{ color: 'var(--color-primary)' }}>
+            {overallAvg !== undefined ? overallAvg.toFixed(2) : '—'}
+          </span>
+          <p className="text-xs" style={{ color: 'color-mix(in srgb, var(--color-text) 50%, transparent)' }}>
+            {t('results.average')}
+          </p>
+        </div>
+
+        {/* Expand toggle */}
+        {hasDetails && (
+          <button
+            onClick={() => setExpanded((v) => !v)}
+            aria-expanded={expanded}
+            aria-label={expanded ? t('results.hide_criteria') : t('results.show_criteria')}
+            className="shrink-0 p-1 rounded hover:opacity-70 transition-opacity"
+            style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}
+          >
+            {expanded ? <ChevronUp size={18} /> : <ChevronDown size={18} />}
+          </button>
+        )}
+      </div>
+
+      {/* Expanded detail */}
+      {expanded && (
+        <div
+          className="px-4 pb-4 space-y-4 pt-3"
+          style={{ borderTop: '1px solid color-mix(in srgb, var(--color-text) 10%, transparent)' }}
+        >
+          {/* Criteria breakdown — skip 'overall' as it's shown in the header */}
+          {activeCriteria.filter((k) => k !== 'overall').length > 0 && (
+            <div className="space-y-2">
+              <p
+                className="text-xs font-semibold uppercase tracking-wide"
+                style={{ color: 'color-mix(in srgb, var(--color-text) 50%, transparent)' }}
+              >
+                {t('results.criteria_breakdown')}
+              </p>
+              <div className="grid grid-cols-2 gap-x-6 gap-y-1.5">
+                {activeCriteria
+                  .filter((k) => k !== 'overall')
+                  .map((key) => {
+                    const avg = result.average_scores[key];
+                    return (
+                      <div key={key} className="flex items-center justify-between gap-2">
+                        <span
+                          className="text-xs"
+                          style={{ color: 'color-mix(in srgb, var(--color-text) 70%, transparent)' }}
+                        >
+                          {t(`criteria.${key}`, { defaultValue: key })}
+                        </span>
+                        <span className="text-xs font-semibold tabular-nums">
+                          {avg !== undefined ? avg.toFixed(2) : '—'}
+                        </span>
+                      </div>
+                    );
+                  })}
+              </div>
+            </div>
+          )}
+
+          {/* Zone distribution */}
+          <div className="space-y-1.5">
+            <p
+              className="text-xs font-semibold uppercase tracking-wide"
+              style={{ color: 'color-mix(in srgb, var(--color-text) 50%, transparent)' }}
+            >
+              {t('results.zone_distribution')}
+            </p>
+            <div className="flex gap-6 text-xs">
+              <ZoneBadge label={t('results.zone_a')} count={result.zone_distribution.zone_a} />
+              <ZoneBadge label={t('results.zone_b')} count={result.zone_distribution.zone_b} />
+              <ZoneBadge label={t('results.zone_none')} count={result.zone_distribution.none} muted />
+            </div>
+          </div>
+
+          {/* Comments (only if show_comments is enabled) */}
+          {showComments && result.comments && result.comments.length > 0 && (
+            <div className="space-y-2">
+              <p
+                className="text-xs font-semibold uppercase tracking-wide"
+                style={{ color: 'color-mix(in srgb, var(--color-text) 50%, transparent)' }}
+              >
+                {t('results.comments')}
+              </p>
+              <ul className="space-y-1.5">
+                {result.comments.map((c, i) => (
+                  <li
+                    key={i}
+                    className="text-sm px-3 py-2 rounded"
+                    style={{ backgroundColor: 'color-mix(in srgb, var(--color-text) 5%, transparent)' }}
+                  >
+                    {c.comment}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ZoneBadge({ label, count, muted }: { label: string; count: number; muted?: boolean }) {
+  return (
+    <span
+      className="flex items-center gap-1"
+      style={{
+        color: muted
+          ? 'color-mix(in srgb, var(--color-text) 45%, transparent)'
+          : 'var(--color-text)',
+      }}
+    >
+      <span className="font-semibold tabular-nums">{count}</span>
+      <span>{label}</span>
+    </span>
   );
 }


### PR DESCRIPTION
## What was done?
Fully implemented the results page (issues #20 and #84).

## Why?
Organizers and helpers need to see tournament results: table ranking, per-criterion averages, zone distribution, and (optionally) anonymized comments.

## Changes

**Backend:**
- `TournamentResults` schema extended: added `active_criteria` (which criteria columns to show) and `show_comments` (whether comments section is visible)
- Handler parses both fields from the tournament's JSON columns and includes them in the API response

**Frontend:**
- `ResultsPage`: ranked list sorted ASC (1 = best school grade)
  - Rank badge (top 3 highlighted in primary color)
  - Table number/name + rating count + overall average
  - Expandable row → per-criterion breakdown (overall excluded from detail, shown in header), zone A/B/none distribution, anonymized comments (only when `show_comments = true`)
- `useResults.ts` hook for `GET /tournaments/{slug}/results`
- EN/DE i18n keys

## Checklist
- [x] Tests passing
- [x] No new dependencies
- [x] No secrets in code
- [x] CLAUDE.md rules followed (ASC ranking, anonymous comments)

Closes #20
Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)