### PR TITLE
feat: legal pages (Imprint + Privacy) from mounted Markdown files (#21)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,13 @@ OAUTH_CALLBACK_URL=https://your-domain.com/api/v1/auth/google/callback
 JWT_SECRET=change-this-to-a-random-secret-at-least-32-chars
 
 # ---------------------------------------------------------------------------
+# Legal texts (Imprint + Privacy Policy)
+# Copy legal/*.example.md to legal/*.md and fill in real content.
+# The ./legal directory is mounted read-only into the container.
+# ---------------------------------------------------------------------------
+LEGAL_PATH=./legal
+
+# ---------------------------------------------------------------------------
 # MinIO (production object storage)
 # Generate credentials with: openssl rand -hex 16
 # ---------------------------------------------------------------------------

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@
 # Uploads (user-generated content)
 uploads/
 
+# Legal texts (contain personal data — operator provides their own files)
+# Copy legal/*.example.md → legal/*.md and fill in real content.
+legal/*.md
+!legal/*.example.md
+
 # Claude Code user-specific settings
 .claude/settings.json
 .claude/settings.local.json

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	Database DatabaseConfig `mapstructure:"database"`
 	Auth     AuthConfig     `mapstructure:"auth"`
 	Storage  StorageConfig  `mapstructure:"storage"`
+	Legal    LegalConfig    `mapstructure:"legal"`
 	Logging  LoggingConfig  `mapstructure:"logging"`
 }
 
@@ -81,6 +82,11 @@ type S3StorageConfig struct {
 	Region    string `mapstructure:"region"`
 	AccessKey string `mapstructure:"access_key"`
 	SecretKey string `mapstructure:"secret_key"`
+}
+
+// LegalConfig holds paths to the mounted legal text files.
+type LegalConfig struct {
+	Path string `mapstructure:"path"` // directory containing imprint.{lang}.md and privacy.{lang}.md
 }
 
 // LoggingConfig holds zerolog settings.

--- a/backend/config/config.yaml
+++ b/backend/config/config.yaml
@@ -32,6 +32,10 @@ storage:
     access_key: ""              # Set via APP_STORAGE_S3_ACCESS_KEY
     secret_key: ""              # Set via APP_STORAGE_S3_SECRET_KEY
 
+legal:
+  path: "./legal"               # directory with imprint.{de,en}.md and privacy.{de,en}.md
+                                # Set via APP_LEGAL_PATH or mount via Docker Compose
+
 logging:
   level: "info"                 # debug | info | warn | error
   format: "json"                # json | pretty (use pretty for local dev only)

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -34,6 +34,11 @@ func NewRouter(cfg *config.Config, jwtSvc *service.JWTService, h *handlers.Handl
 		r.Static("/uploads", cfg.Storage.Local.Path)
 	}
 
+	// Serve legal text files (imprint.{lang}.md, privacy.{lang}.md) from mounted directory.
+	if cfg.Legal.Path != "" {
+		r.Static("/legal", cfg.Legal.Path)
+	}
+
 	strictHandler := generated.NewStrictHandler(h, nil)
 	generated.RegisterHandlers(r.Group("/api/v1"), strictHandler)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,8 +93,10 @@ services:
       APP_STORAGE_S3_ACCESS_KEY: ${MINIO_ACCESS_KEY}
       APP_STORAGE_S3_SECRET_KEY: ${MINIO_SECRET_KEY}
       APP_LOGGING_LEVEL: ${LOG_LEVEL:-info}
+      APP_LEGAL_PATH: /legal
     volumes:
       - ./turnscore-config.yaml:/config/config.yaml:ro
+      - ./legal:/legal:ro
     networks:
       - proxy
       - backend

--- a/frontend/src/components/legal/LegalBody.tsx
+++ b/frontend/src/components/legal/LegalBody.tsx
@@ -1,0 +1,47 @@
+import Markdown from 'react-markdown';
+import { TFunction } from 'i18next';
+
+interface Props {
+  status: 'loading' | 'ok' | 'error';
+  content: string;
+  t: TFunction;
+}
+
+/**
+ * Renders the body of a legal page: loading skeleton, error message, or Markdown content.
+ */
+export function LegalBody({ status, content, t }: Props) {
+  if (status === 'loading') {
+    return (
+      <div className="space-y-3 animate-pulse">
+        {[100, 90, 95, 70].map((w, i) => (
+          <div
+            key={i}
+            className="h-4 rounded"
+            style={{
+              width: `${w}%`,
+              backgroundColor: 'color-mix(in srgb, var(--color-text) 12%, transparent)',
+            }}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <p className="text-sm" style={{ color: 'color-mix(in srgb, var(--color-text) 55%, transparent)' }}>
+        {t('legal.not_available')}
+      </p>
+    );
+  }
+
+  return (
+    <div
+      className="prose prose-sm max-w-none"
+      style={{ color: 'var(--color-text)' }}
+    >
+      <Markdown>{content}</Markdown>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useLegalContent.ts
+++ b/frontend/src/hooks/useLegalContent.ts
@@ -1,0 +1,49 @@
+import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+
+type LegalPage = 'imprint' | 'privacy';
+type Status = 'loading' | 'ok' | 'error';
+
+interface LegalContent {
+  content: string;
+  status: Status;
+}
+
+/**
+ * Fetches the Markdown file for the given legal page in the active language.
+ * Falls back to English if the language-specific file is not found.
+ * Files are served from /legal/{page}.{lang}.md (mounted via Docker Compose).
+ */
+export function useLegalContent(page: LegalPage): LegalContent {
+  const { i18n } = useTranslation();
+  const [content, setContent] = useState('');
+  const [status, setStatus] = useState<Status>('loading');
+
+  useEffect(() => {
+    const lang = i18n.language.startsWith('de') ? 'de' : 'en';
+
+    async function load() {
+      setStatus('loading');
+      const res = await fetch(`/legal/${page}.${lang}.md`);
+      if (res.ok) {
+        setContent(await res.text());
+        setStatus('ok');
+        return;
+      }
+      // Fallback to English
+      if (lang !== 'en') {
+        const fallback = await fetch(`/legal/${page}.en.md`);
+        if (fallback.ok) {
+          setContent(await fallback.text());
+          setStatus('ok');
+          return;
+        }
+      }
+      setStatus('error');
+    }
+
+    load();
+  }, [page, i18n.language]);
+
+  return { content, status };
+}

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -280,5 +280,8 @@
     "edit": "Bearbeiten",
     "back": "Zurück",
     "close": "Schließen"
+  },
+  "legal": {
+    "not_available": "Dieser Inhalt ist zurzeit nicht verfügbar."
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -280,5 +280,8 @@
     "edit": "Edit",
     "back": "Back",
     "close": "Close"
+  },
+  "legal": {
+    "not_available": "This content is currently not available."
   }
 }

--- a/frontend/src/pages/ImprintPage.tsx
+++ b/frontend/src/pages/ImprintPage.tsx
@@ -1,16 +1,19 @@
 import { useTranslation } from 'react-i18next';
 import { AppLayout } from '@/components/layout/AppLayout';
+import { LegalBody } from '@/components/legal/LegalBody';
+import { useLegalContent } from '@/hooks/useLegalContent';
 
 export function ImprintPage() {
   const { t } = useTranslation();
+  const { content, status } = useLegalContent('imprint');
 
   return (
     <AppLayout>
       <main className="container mx-auto px-4 py-8 max-w-2xl">
-        <h1 className="font-heading text-2xl font-bold mb-4">{t('nav.imprint')}</h1>
-        <p className="text-sm" style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}>
-          Imprint content to be added.
-        </p>
+        <h1 className="font-heading text-2xl font-bold mb-6" style={{ color: 'var(--color-text)' }}>
+          {t('nav.imprint')}
+        </h1>
+        <LegalBody status={status} content={content} t={t} />
       </main>
     </AppLayout>
   );

--- a/frontend/src/pages/PrivacyPage.tsx
+++ b/frontend/src/pages/PrivacyPage.tsx
@@ -1,16 +1,19 @@
 import { useTranslation } from 'react-i18next';
 import { AppLayout } from '@/components/layout/AppLayout';
+import { LegalBody } from '@/components/legal/LegalBody';
+import { useLegalContent } from '@/hooks/useLegalContent';
 
 export function PrivacyPage() {
   const { t } = useTranslation();
+  const { content, status } = useLegalContent('privacy');
 
   return (
     <AppLayout>
       <main className="container mx-auto px-4 py-8 max-w-2xl">
-        <h1 className="font-heading text-2xl font-bold mb-4">{t('nav.privacy')}</h1>
-        <p className="text-sm" style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}>
-          Privacy policy content to be added.
-        </p>
+        <h1 className="font-heading text-2xl font-bold mb-6" style={{ color: 'var(--color-text)' }}>
+          {t('nav.privacy')}
+        </h1>
+        <LegalBody status={status} content={content} t={t} />
       </main>
     </AppLayout>
   );

--- a/legal/imprint.de.example.md
+++ b/legal/imprint.de.example.md
@@ -1,0 +1,17 @@
+# Impressum
+
+**Angaben gemäß § 5 TMG**
+
+Vorname Nachname  
+Musterstraße 1  
+12345 Musterstadt  
+Deutschland
+
+**Kontakt**
+
+E-Mail: kontakt@beispiel.de
+
+**Verantwortlich für den Inhalt nach § 55 Abs. 2 RStV**
+
+Vorname Nachname  
+Anschrift wie oben

--- a/legal/imprint.en.example.md
+++ b/legal/imprint.en.example.md
@@ -1,0 +1,12 @@
+# Imprint
+
+**Information according to § 5 TMG**
+
+First Last  
+Sample Street 1  
+12345 Sample City  
+Germany
+
+**Contact**
+
+Email: contact@example.com

--- a/legal/privacy.de.example.md
+++ b/legal/privacy.de.example.md
@@ -1,0 +1,29 @@
+# Datenschutzerklärung
+
+## 1. Verantwortlicher
+
+Vorname Nachname, Musterstraße 1, 12345 Musterstadt  
+E-Mail: kontakt@beispiel.de
+
+## 2. Erhobene Daten
+
+Diese Anwendung verarbeitet folgende personenbezogene Daten:
+
+- **Google-Konto** (Name, E-Mail-Adresse) bei der Anmeldung als Organisator oder Helfer
+- **Nickname** bei der Anmeldung als Bewerter (kein Klarbezug zur Person)
+- **Bewertungen und Kommentare** (anonym, ohne Personenbezug)
+- **Fotos** der Spieltische (keine Personen abgebildet)
+
+## 3. Rechtsgrundlage
+
+Die Verarbeitung erfolgt auf Grundlage von Art. 6 Abs. 1 lit. b DSGVO (Vertragserfüllung)
+sowie Art. 6 Abs. 1 lit. f DSGVO (berechtigtes Interesse am Turnierbetrieb).
+
+## 4. Speicherdauer
+
+Daten werden gelöscht, sobald das Turnier archiviert und vom Organisator gelöscht wird.
+
+## 5. Ihre Rechte
+
+Sie haben das Recht auf Auskunft, Berichtigung, Löschung und Einschränkung der Verarbeitung.
+Wenden Sie sich dazu an die oben genannte Kontaktadresse.

--- a/legal/privacy.en.example.md
+++ b/legal/privacy.en.example.md
@@ -1,0 +1,29 @@
+# Privacy Policy
+
+## 1. Controller
+
+First Last, Sample Street 1, 12345 Sample City  
+Email: contact@example.com
+
+## 2. Data Collected
+
+This application processes the following personal data:
+
+- **Google account** (name, email address) when signing in as organizer or helper
+- **Nickname** when signing in as a rater (no link to a real person)
+- **Ratings and comments** (anonymous, no personal reference)
+- **Photos** of game tables (no persons depicted)
+
+## 3. Legal Basis
+
+Processing is based on Art. 6(1)(b) GDPR (performance of a contract) and
+Art. 6(1)(f) GDPR (legitimate interest in running the tournament).
+
+## 4. Retention
+
+Data is deleted once a tournament is archived and removed by the organizer.
+
+## 5. Your Rights
+
+You have the right to access, rectify, erase, and restrict processing of your data.
+Please contact the address above.


### PR DESCRIPTION
## What was done?
Implemented `/imprint` and `/privacy` pages with content from operator-provided Markdown files mounted via Docker Compose.

## How it works
- Backend serves `./legal/` as a static directory at `/legal`
- Frontend detects active language (`de`/`en`) and fetches `/legal/{page}.{lang}.md`
- Falls back to English if the language-specific file is missing
- Rendered with `react-markdown`

## Ops setup (on server)
```bash
cp legal/imprint.de.example.md legal/imprint.de.md
cp legal/imprint.en.example.md legal/imprint.en.md
cp legal/privacy.de.example.md legal/privacy.de.md
cp legal/privacy.en.example.md legal/privacy.en.md
# edit files with real content
```
The `legal/` directory is in `.gitignore` (contains personal data) — only `*.example.md` templates are committed.

## Checklist
- [x] Tests: `go build` + `tsc` pass
- [x] No secrets in code
- [x] CLAUDE.md rules followed

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)