### PR TITLE
fix: proxy /legal and /uploads to backend in Vite dev server

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -41,9 +41,11 @@ services:
       APP_STORAGE_LOCAL_BASE_URL: http://192.168.1.122:8080
       APP_LOGGING_LEVEL: debug
       APP_LOGGING_FORMAT: pretty
+      APP_LEGAL_PATH: /legal
     volumes:
       - ./backend:/app
       - uploads_dev_data:/app/uploads
+      - ./legal:/legal:ro
     ports:
       - "8080:8080"
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -16,6 +16,14 @@ export default defineConfig({
         target: process.env.VITE_API_URL || 'http://localhost:8080',
         changeOrigin: true,
       },
+      '/uploads': {
+        target: process.env.VITE_API_URL || 'http://localhost:8080',
+        changeOrigin: true,
+      },
+      '/legal': {
+        target: process.env.VITE_API_URL || 'http://localhost:8080',
+        changeOrigin: true,
+      },
     },
   },
 });


### PR DESCRIPTION
## What was done?
Added `/legal` and `/uploads` proxy entries to the Vite dev server config.

## Why?
`fetch('/legal/imprint.de.md')` was hitting the Vite dev server (port 3000) instead of the Go backend (port 8080), which returned `index.html` (SPA fallback). Only `/api` was proxied previously.

Also mounts `./legal:/legal:ro` into the backend dev container so the Go router can serve the files.

## Checklist
- [x] No secrets in code
- [x] CLAUDE.md rules followed

🤖 Generated with [Claude Code](https://claude.com/claude-code)