### PR TITLE
fix(storage): ensure S3 bucket exists on startup

### DIFF
--- a/backend/internal/storage/s3.go
+++ b/backend/internal/storage/s3.go
@@ -60,11 +60,15 @@ func newS3Client(cfg config.S3StorageConfig) *s3.Client {
 }
 
 func newS3Storage(cfg config.S3StorageConfig) (*S3Storage, error) {
-	return &S3Storage{
+	stor := &S3Storage{
 		client:   newS3Client(cfg),
 		bucket:   cfg.Bucket,
 		endpoint: strings.TrimRight(cfg.Endpoint, "/"),
-	}, nil
+	}
+	if err := EnsureBucketExists(context.Background(), cfg); err != nil {
+		return nil, fmt.Errorf("s3 storage init: %w", err)
+	}
+	return stor, nil
 }
 
 // EnsureBucketExists creates the bucket if it does not already exist.


### PR DESCRIPTION
## What was done?

Call `EnsureBucketExists` inside `newS3Storage` so the bucket is created at initialization time if it doesn't exist yet.

`CreateBucket` for an already-existing bucket is a no-op (`BucketAlreadyExists` / `BucketAlreadyOwnedByYou` are silently ignored), so this costs one lightweight API call at startup.

## Why?

Fixes #124. `minio-init` + `depends_on: service_completed_successfully` (from #121) guarantees bucket + public-read policy at first start. `EnsureBucketExists` in the app code is the safety net for when the bucket is missing for other reasons (e.g. manual deletion) without a full `docker compose down/up` cycle.

The anonymous read policy remains `minio-init`'s responsibility — if the volume is wiped a full redeploy is required regardless.

## Checklist
- [x] No secrets in code
- [x] CLAUDE.md rules followed