### PR TITLE
fix(storage): replace EndpointResolverV2 with BaseEndpoint for MinIO

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -25,7 +25,6 @@ require (
 )
 
 require (
-	github.com/aws/smithy-go v1.21.0
 	github.com/disintegration/imaging v1.6.2
 	github.com/gin-gonic/gin v1.12.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
@@ -62,6 +61,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.19.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.22.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.27.0 // indirect
+	github.com/aws/smithy-go v1.21.0 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic v1.15.0 // indirect
 	github.com/bytedance/sonic/loader v0.5.0 // indirect

--- a/backend/internal/storage/s3.go
+++ b/backend/internal/storage/s3.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/url"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -13,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
-	smithyendpoints "github.com/aws/smithy-go/endpoints"
 
 	"github.com/r3st/turnscore/config"
 )
@@ -23,19 +21,6 @@ type S3Storage struct {
 	client   *s3.Client
 	bucket   string
 	endpoint string
-}
-
-// staticEndpointResolver directs all S3 API calls to a fixed endpoint URL (e.g. MinIO).
-type staticEndpointResolver struct {
-	url string
-}
-
-func (r staticEndpointResolver) ResolveEndpoint(_ context.Context, _ s3.EndpointParameters) (smithyendpoints.Endpoint, error) {
-	u, err := url.Parse(r.url)
-	if err != nil {
-		return smithyendpoints.Endpoint{}, fmt.Errorf("parse endpoint URL: %w", err)
-	}
-	return smithyendpoints.Endpoint{URI: *u}, nil
 }
 
 func newS3Client(cfg config.S3StorageConfig) *s3.Client {
@@ -51,9 +36,9 @@ func newS3Client(cfg config.S3StorageConfig) *s3.Client {
 		func(o *s3.Options) { o.UsePathStyle = true },
 	}
 	if cfg.Endpoint != "" {
-		resolver := staticEndpointResolver{url: strings.TrimRight(cfg.Endpoint, "/")}
+		endpoint := strings.TrimRight(cfg.Endpoint, "/")
 		s3Opts = append(s3Opts, func(o *s3.Options) {
-			o.EndpointResolverV2 = resolver
+			o.BaseEndpoint = aws.String(endpoint)
 		})
 	}
 	return s3.NewFromConfig(awsCfg, s3Opts...)


### PR DESCRIPTION
## What was done?

Replaced the custom `staticEndpointResolver` / `EndpointResolverV2` with `o.BaseEndpoint = aws.String(endpoint)` in `newS3Client`.

Removed the now-unused `staticEndpointResolver` struct, `net/url` import, and `smithy-go/endpoints` direct dependency (moves to indirect).

## Why?

Fixes #126. When `EndpointResolverV2` is set, the AWS SDK v2 ignores `UsePathStyle = true` and falls back to virtual-hosted style. `CreateBucket` (and `PutObject`/`DeleteObject`) are sent to `PUT /` instead of `PUT /bucketname`, which MinIO rejects with `400 BadRequest: An unsupported API call for method: PUT at '/'`.

`BaseEndpoint` is the recommended modern approach for custom endpoints and correctly respects `UsePathStyle`.

## Checklist
- [x] No secrets in code
- [x] CLAUDE.md rules followed