### PR TITLE
fix(storage): proxy S3 photos through app instead of direct MinIO URL

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -655,6 +655,46 @@ components:
 paths:
 
   # =========================================================================
+  # Static file serving
+  # =========================================================================
+
+  /uploads/{key}:
+    get:
+      summary: Serve an uploaded file (photo or thumbnail)
+      description: >
+        Streams a stored file (original photo or thumbnail) through the app server.
+        For local storage the file is read from the filesystem; for S3/MinIO it is
+        proxied via GetObject. The path segment `key` matches the storage key returned
+        in `photo.url` and `photo.thumbnailUrl` (with the `/uploads/` prefix stripped).
+      operationId: getUpload
+      tags: [Uploads]
+      parameters:
+        - name: key
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Storage key, e.g. `tables/{tableId}/general/{photoId}.jpg`
+      responses:
+        "200":
+          description: File contents
+          content:
+            image/jpeg:
+              schema:
+                type: string
+                format: binary
+            image/png:
+              schema:
+                type: string
+                format: binary
+            image/webp:
+              schema:
+                type: string
+                format: binary
+        "404":
+          description: File not found
+
+  # =========================================================================
   # Auth
   # =========================================================================
 

--- a/backend/cmd/server/root.go
+++ b/backend/cmd/server/root.go
@@ -157,7 +157,7 @@ func runServer(cmd *cobra.Command, args []string) error {
 
 	// --- Handlers & Router ---
 	h := handlers.New(tournamentSvc, tableSvc, qrSvc, raterSvc, userSvc, authSvc, cfg.Server.FrontendURL)
-	router := api.NewRouter(cfg, jwtSvc, h)
+	router := api.NewRouter(cfg, jwtSvc, h, stor)
 
 	// --- HTTP Server with graceful shutdown ---
 	addr := fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port)

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -3,7 +3,10 @@ package api
 
 import (
 	"io/fs"
+	"mime"
 	"net/http"
+	"path/filepath"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
@@ -14,11 +17,12 @@ import (
 	"github.com/r3st/turnscore/internal/devusers"
 	"github.com/r3st/turnscore/internal/service"
 	"github.com/r3st/turnscore/internal/static"
+	"github.com/r3st/turnscore/internal/storage"
 )
 
 // NewRouter builds and returns a configured Gin engine.
 // Authentication is enforced per-handler; OptionalAuth globally extracts the token when present.
-func NewRouter(cfg *config.Config, jwtSvc *service.JWTService, h *handlers.Handlers) *gin.Engine {
+func NewRouter(cfg *config.Config, jwtSvc *service.JWTService, h *handlers.Handlers, stor storage.Storage) *gin.Engine {
 	if cfg.Server.Mode == "release" {
 		gin.SetMode(gin.ReleaseMode)
 	}
@@ -29,10 +33,8 @@ func NewRouter(cfg *config.Config, jwtSvc *service.JWTService, h *handlers.Handl
 	r.Use(middleware.RequestLogger())
 	r.Use(middleware.OptionalAuth(jwtSvc))
 
-	// Serve uploaded files for local storage backend.
-	if cfg.Storage.Backend == "local" {
-		r.Static("/uploads", cfg.Storage.Local.Path)
-	}
+	// Serve uploaded files via the storage backend (local filesystem or S3 proxy).
+	r.GET("/uploads/*key", uploadsHandler(stor))
 
 	// Serve legal text files (imprint.{lang}.md, privacy.{lang}.md) from mounted directory.
 	if cfg.Legal.Path != "" {
@@ -92,6 +94,26 @@ func spaHandler(distFS fs.FS) gin.HandlerFunc {
 		}
 		c.Data(http.StatusOK, "text/html; charset=utf-8", data)
 		c.Abort()
+	}
+}
+
+// uploadsHandler streams files from the storage backend under /uploads/*key.
+// For local storage this reads from the filesystem; for S3 it proxies via GetObject.
+func uploadsHandler(stor storage.Storage) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		key := strings.TrimPrefix(c.Param("key"), "/")
+		rc, err := stor.Open(c.Request.Context(), key)
+		if err != nil {
+			c.Status(http.StatusNotFound)
+			return
+		}
+		defer rc.Close()
+		contentType := mime.TypeByExtension(filepath.Ext(key))
+		if contentType == "" {
+			contentType = "application/octet-stream"
+		}
+		c.Header("Cache-Control", "public, max-age=31536000, immutable")
+		c.DataFromReader(http.StatusOK, -1, contentType, rc, nil)
 	}
 }
 

--- a/backend/internal/storage/interface.go
+++ b/backend/internal/storage/interface.go
@@ -13,6 +13,8 @@ import (
 type Storage interface {
 	// Put stores the content from r under the given key.
 	Put(ctx context.Context, key string, r io.Reader, size int64, contentType string) error
+	// Open returns a ReadCloser for the file identified by key. Caller must close it.
+	Open(ctx context.Context, key string) (io.ReadCloser, error)
 	// Delete removes the file identified by key.
 	Delete(ctx context.Context, key string) error
 	// PublicURL returns the publicly accessible URL for the given key.

--- a/backend/internal/storage/local.go
+++ b/backend/internal/storage/local.go
@@ -44,6 +44,16 @@ func (s *LocalStorage) Put(_ context.Context, key string, r io.Reader, _ int64, 
 	return nil
 }
 
+// Open returns a ReadCloser for the file at basePath/key. Caller must close it.
+func (s *LocalStorage) Open(_ context.Context, key string) (io.ReadCloser, error) {
+	fullPath := filepath.Join(s.basePath, filepath.FromSlash(key))
+	f, err := os.Open(fullPath)
+	if err != nil {
+		return nil, fmt.Errorf("opening file: %w", err)
+	}
+	return f, nil
+}
+
 // Delete removes the file at basePath/key.
 func (s *LocalStorage) Delete(_ context.Context, key string) error {
 	fullPath := filepath.Join(s.basePath, filepath.FromSlash(key))

--- a/backend/internal/storage/s3.go
+++ b/backend/internal/storage/s3.go
@@ -18,9 +18,8 @@ import (
 
 // S3Storage stores files in an S3-compatible object store (AWS S3, Cloudflare R2, MinIO).
 type S3Storage struct {
-	client   *s3.Client
-	bucket   string
-	endpoint string
+	client *s3.Client
+	bucket string
 }
 
 func newS3Client(cfg config.S3StorageConfig) *s3.Client {
@@ -46,9 +45,8 @@ func newS3Client(cfg config.S3StorageConfig) *s3.Client {
 
 func newS3Storage(cfg config.S3StorageConfig) (*S3Storage, error) {
 	stor := &S3Storage{
-		client:   newS3Client(cfg),
-		bucket:   cfg.Bucket,
-		endpoint: strings.TrimRight(cfg.Endpoint, "/"),
+		client: newS3Client(cfg),
+		bucket: cfg.Bucket,
 	}
 	if err := EnsureBucketExists(context.Background(), cfg); err != nil {
 		return nil, fmt.Errorf("s3 storage init: %w", err)
@@ -101,10 +99,20 @@ func (s *S3Storage) Delete(ctx context.Context, key string) error {
 	return nil
 }
 
-// PublicURL returns the public URL for the given key.
-func (s *S3Storage) PublicURL(key string) string {
-	if s.endpoint != "" {
-		return fmt.Sprintf("%s/%s/%s", s.endpoint, s.bucket, key)
+// Open returns a ReadCloser streaming the S3 object for the given key. Caller must close it.
+func (s *S3Storage) Open(ctx context.Context, key string) (io.ReadCloser, error) {
+	out, err := s.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("s3 get object: %w", err)
 	}
-	return fmt.Sprintf("https://%s.s3.amazonaws.com/%s", s.bucket, key)
+	return out.Body, nil
+}
+
+// PublicURL returns the app-relative URL for the given key.
+// Photos are served via the /uploads/* proxy handler, not directly from S3.
+func (s *S3Storage) PublicURL(key string) string {
+	return "/uploads/" + key
 }

--- a/backend/internal/storage/s3_test.go
+++ b/backend/internal/storage/s3_test.go
@@ -3,6 +3,7 @@ package storage_test
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
@@ -81,8 +82,25 @@ func TestS3Storage_PutDeletePublicURL(t *testing.T) {
 		err := s.Put(ctx, key, strings.NewReader(content), int64(len(content)), "image/jpeg")
 		require.NoError(t, err)
 
+		// PublicURL must return an app-relative path, not a direct MinIO URL.
 		url := s.PublicURL(key)
-		assert.Equal(t, fmt.Sprintf("%s/%s/%s", endpoint, minioBucket, key), url)
+		assert.Equal(t, "/uploads/"+key, url)
+	})
+
+	t.Run("Open", func(t *testing.T) {
+		key := "tables/abc/general/readable.jpg"
+		content := "readable-content"
+
+		err := s.Put(ctx, key, strings.NewReader(content), int64(len(content)), "image/jpeg")
+		require.NoError(t, err)
+
+		rc, err := s.Open(ctx, key)
+		require.NoError(t, err)
+		defer rc.Close()
+
+		got, err := io.ReadAll(rc)
+		require.NoError(t, err)
+		assert.Equal(t, content, string(got))
 	})
 
 	t.Run("Delete", func(t *testing.T) {

--- a/backend/pkg/mocks/mock_storage.go
+++ b/backend/pkg/mocks/mock_storage.go
@@ -21,7 +21,6 @@ import (
 type MockStorage struct {
 	ctrl     *gomock.Controller
 	recorder *MockStorageMockRecorder
-	isgomock struct{}
 }
 
 // MockStorageMockRecorder is the mock recorder for MockStorage.
@@ -42,43 +41,58 @@ func (m *MockStorage) EXPECT() *MockStorageMockRecorder {
 }
 
 // Delete mocks base method.
-func (m *MockStorage) Delete(ctx context.Context, key string) error {
+func (m *MockStorage) Delete(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, key)
+	ret := m.ctrl.Call(m, "Delete", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockStorageMockRecorder) Delete(ctx, key any) *gomock.Call {
+func (mr *MockStorageMockRecorder) Delete(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStorage)(nil).Delete), ctx, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStorage)(nil).Delete), arg0, arg1)
+}
+
+// Open mocks base method.
+func (m *MockStorage) Open(arg0 context.Context, arg1 string) (io.ReadCloser, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Open", arg0, arg1)
+	ret0, _ := ret[0].(io.ReadCloser)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Open indicates an expected call of Open.
+func (mr *MockStorageMockRecorder) Open(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Open", reflect.TypeOf((*MockStorage)(nil).Open), arg0, arg1)
 }
 
 // PublicURL mocks base method.
-func (m *MockStorage) PublicURL(key string) string {
+func (m *MockStorage) PublicURL(arg0 string) string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PublicURL", key)
+	ret := m.ctrl.Call(m, "PublicURL", arg0)
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
 // PublicURL indicates an expected call of PublicURL.
-func (mr *MockStorageMockRecorder) PublicURL(key any) *gomock.Call {
+func (mr *MockStorageMockRecorder) PublicURL(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicURL", reflect.TypeOf((*MockStorage)(nil).PublicURL), key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicURL", reflect.TypeOf((*MockStorage)(nil).PublicURL), arg0)
 }
 
 // Put mocks base method.
-func (m *MockStorage) Put(ctx context.Context, key string, r io.Reader, size int64, contentType string) error {
+func (m *MockStorage) Put(arg0 context.Context, arg1 string, arg2 io.Reader, arg3 int64, arg4 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Put", ctx, key, r, size, contentType)
+	ret := m.ctrl.Call(m, "Put", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Put indicates an expected call of Put.
-func (mr *MockStorageMockRecorder) Put(ctx, key, r, size, contentType any) *gomock.Call {
+func (mr *MockStorageMockRecorder) Put(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockStorage)(nil).Put), ctx, key, r, size, contentType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockStorage)(nil).Put), arg0, arg1, arg2, arg3, arg4)
 }


### PR DESCRIPTION
## What was done?

Photos stored in S3/MinIO are now served through the Turnscore app itself at `/uploads/*key` — exactly like local storage. MinIO stays internal and is never exposed to browsers.

### Changes

| File | Change |
|---|---|
| `storage/interface.go` | Added `Open(ctx, key) (io.ReadCloser, error)` |
| `storage/local.go` | Implemented `Open` via `os.Open` |
| `storage/s3.go` | Implemented `Open` via `GetObject`; `PublicURL` → `/uploads/{key}`; removed unused `endpoint` field |
| `router.go` | Replaced `r.Static("/uploads", ...)` with unified `uploadsHandler(stor)` for both backends; sets `Cache-Control: immutable` |
| `root.go` | Pass `stor` to `NewRouter` |
| `s3_test.go` | Updated `PublicURL` assertion; added `Open` round-trip test case |

## Why?

Fixes #128. `S3Storage.PublicURL` was returning `http://minio:9000/...` — an internal Docker hostname unreachable from browsers, causing CORS errors and broken images.

## Checklist
- [x] Tests updated and passing
- [x] No secrets in code
- [x] CLAUDE.md rules followed