### PR TITLE
fix(frontend): remove tournament invalidation from useUpdateResultConfig

### DIFF
--- a/frontend/src/api/hooks/useTournaments.ts
+++ b/frontend/src/api/hooks/useTournaments.ts
@@ -62,10 +62,8 @@ export function useDeleteTournament() {
 }
 
 export function useUpdateResultConfig(slug: string) {
-  const qc = useQueryClient();
   return useMutation<ResultConfig, Error, ResultConfig>({
     mutationFn: (body) =>
       apiClient.put(`/tournaments/${slug}/result-config`, body).then((r) => r.data),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['tournaments', slug] }),
   });
 }


### PR DESCRIPTION
## What was done?

Removed `qc.invalidateQueries({ queryKey: ['tournaments', slug] })` from `useUpdateResultConfig.onSuccess` and the now-unused `const qc = useQueryClient()` in that hook.

## Why?

Fixes #130. `updateResultConfig.onSuccess` was refetching the full tournament, which triggered `TournamentEditPage`'s `useEffect([tournament])` and reset all form fields — including the status dropdown — from server values. Any unsaved status change was silently lost before the user could click the main Save button.

`showComments` and `visibleCriteria` are local state never read from the tournament query, so the invalidation served no purpose.

## Checklist
- [x] No secrets in code
- [x] CLAUDE.md rules followed