### PR TITLE
fix(frontend): remove unused useMe/me from TournamentEditPage

### DIFF
--- a/frontend/src/pages/dashboard/TournamentEditPage.tsx
+++ b/frontend/src/pages/dashboard/TournamentEditPage.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { useMe } from '@/api/hooks/useUser';
 import {
   useTournament,
   useCreateTournament,
@@ -23,7 +22,6 @@ export function TournamentEditPage() {
   const { slug } = useParams<{ slug?: string }>();
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { data: me } = useMe();
   const isNew = !slug;
 
   const { data: tournament, isLoading } = useTournament(slug ?? '');


### PR DESCRIPTION
## What was done?
Removed unused `useMe` import and `me` variable from `TournamentEditPage`.

## Why?
Another leftover from the Result Config refactor (#133). `tsc` fails with TS6133 during Docker build. Fixes #134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)